### PR TITLE
Allow repeated calls to reset and restore

### DIFF
--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -281,7 +281,9 @@ FetchMock.prototype.restore = function () {
 	this.isMocking = false;
 	this.reset();
 	if (this.usesGlobalFetch) {
-		theGlobal.fetch.restore();
+		if(typeof theGlobal.fetch.restore === 'function') {
+			theGlobal.fetch.restore();
+		}
 	} else if (this.fetch) {
 		this.fetch.restore();
 	}
@@ -297,7 +299,9 @@ FetchMock.prototype.reset = function () {
 	debug('resetting call logs');
 	this._calls = {};
 	if (this.usesGlobalFetch) {
-		theGlobal.fetch.reset();
+		if(typeof theGlobal.fetch.reset === 'function') {
+			theGlobal.fetch.reset();
+		}
 	} else if (this.fetch) {
 		this.fetch.reset();
 	}


### PR DESCRIPTION
Hi Rhys, I've done this hacky little fix to allow restore and reset to fail silently when they're not valid to call (called multiple times between new mocking behaviour specified?). I don't fully understand how it works, so you might be able to see a more elegant way to make this work.

Doing this allows me to put fetchMock.restore in the afterEach function instead of in the then and catch blocks of each test.