### PR TITLE
V3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-mock",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Mock http requests made using fetch (or isomorphic-fetch)",
   "main": "src/server.js",
   "browser": "es5/client.js",

--- a/test/server.js
+++ b/test/server.js
@@ -30,12 +30,12 @@ describe('non-global use', function () {
 
 		fetchMock.useNonGlobalFetch(dummyFetch);
 		expect(fetchMock.realFetch).to.equal(dummyFetch);
-		var mock = fetchMock.mock();
+		var mock = fetchMock.mock().getMock();
 		expect(typeof mock).to.equal('function');
 		expect(function () {
 			mock('url', {prop: 'val'})
 		}).not.to.throw();
-		expect(fetchMock.called('__unmatched')).to.be.true;
+		expect(fetchMock.calls().unmatched.length).to.equal(1);
 		expect(fetchCalls.length).to.equal(1);
 		expect(fetchCalls[0]).to.eql(['url', {prop: 'val'}]);
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -203,20 +203,21 @@ module.exports = function (fetchMock, theGlobal) {
 						fetch('http://2', {method: 'POST'})
 					])
 						.then(function () {
-							expect(fetchMock.called()).to.be.true;
+							expect(fetchMock.called()).to.be.false;
 							var unmatchedCalls = fetchMock.calls().unmatched;
 							expect(unmatchedCalls.length).to.equal(2);
 							expect(unmatchedCalls[0]).to.eql(['http://1', {method: 'GET'}]);
 							expect(unmatchedCalls[1]).to.eql(['http://2', {method: 'POST'}]);
 							done();
-						});
+						})
+
 				});
 
 				it('configure to send good responses', function (done) {
 					fetchMock.mock({greed: 'good'});
 					fetch('http://1')
 						.then(function (res) {
-							expect(fetchMock.called()).to.be.true;
+							expect(fetchMock.called()).to.be.false;
 							expect(fetchMock.calls().unmatched.length).to.equal(1);
 							expect(res.status).to.equal(200);
 							res.text().then(function (text) {
@@ -230,7 +231,7 @@ module.exports = function (fetchMock, theGlobal) {
 					fetchMock.mock({greed: 'bad'});
 					fetch('http://1')
 						.catch(function (res) {
-							expect(fetchMock.called()).to.be.true;
+							expect(fetchMock.called()).to.be.false;
 							expect(res).to.equal('unmocked url: http://1');
 							done();
 						});
@@ -240,12 +241,13 @@ module.exports = function (fetchMock, theGlobal) {
 					fetchMock.mock({greed: 'none'});
 					fetch('http://1')
 						.then(function () {
-							expect(fetchMock.called()).to.be.true;
-							expect(fetchMock.calls().matched.length).to.equal(1);
+							expect(fetchMock.called()).to.be.false;
+							expect(fetchMock.calls().unmatched.length).to.equal(1);
 							expect(fetchCalls.length).to.equal(1);
 							expect(fetchCalls[0].length).to.equal(2);
 							done();
-						})
+						});
+
 				});
 
 			});


### PR DESCRIPTION
A few changes to make the API a bit less verbose and clean up how calls are retrieved

- `mock()` is chainable
- route names now default to `matcher.toString()`
- `getMock()` method added for use with mockery
- `calls()` returns an object `{matched: [], unmatched: []}`
- `called()` only returns `true` if fetch-mock matched a route (use `calls().unmatched for examining unmatched calls)