### PR TITLE
check if matcher's first arg is Request

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -4,6 +4,7 @@ const FetchMock = require('./fetch-mock');
 
 module.exports = new FetchMock({
 	theGlobal: window,
+	Request: window.Request,
 	Response: window.Response,
 	Headers: window.Headers,
 	Blob: window.Blob,

--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -59,7 +59,7 @@ function mockResponse (url, config) {
 
 function toRequest(url, options) {
 	var request;
-	if (Request.prototype.isPrototypeOf(url) && !options) {
+	if (Request.prototype.isPrototypeOf(url)) {
 		request = url;
 	} else {
 		request = new Request(url, options);
@@ -73,8 +73,8 @@ function compileRoute (route) {
   var matchMethod;
   if(method) {
     method = method.toLowerCase();
-    matchMethod = function(options) {
-      var m = options && options.method ? options.method.toLowerCase() : 'get';
+    matchMethod = function(req) {
+      var m = req && req.method ? req.method.toLowerCase() : 'get';
       return m === method;
     };
   } else {

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Request = require('node-fetch').Request;
 const Response = require('node-fetch').Response;
 const Headers = require('node-fetch').Headers;
 const stream = require('stream');
@@ -7,6 +8,7 @@ const FetchMock = require('./fetch-mock');
 
 module.exports = new FetchMock({
 	theGlobal: GLOBAL,
+	Request: Request,
 	Response: Response,
 	Headers: Headers,
 	stream: stream,

--- a/test/server.js
+++ b/test/server.js
@@ -33,11 +33,11 @@ describe('non-global use', function () {
 		var mock = fetchMock.mock().getMock();
 		expect(typeof mock).to.equal('function');
 		expect(function () {
-			mock('url', {prop: 'val'})
+			mock('http://url', {prop: 'val'})
 		}).not.to.throw();
 		expect(fetchMock.calls().unmatched.length).to.equal(1);
 		expect(fetchCalls.length).to.equal(1);
-		expect(fetchCalls[0]).to.eql(['url', {prop: 'val'}]);
+		expect(fetchCalls[0]).to.eql(['http://url', {prop: 'val'}]);
 
 		fetchMock.restore();
 		fetchMock.usesGlobalFetch = true;


### PR DESCRIPTION
A fetch could be called with Request param, instead of plain string url.
This code will fail to match
```js
fetchMock.mock('http://domain1', 200);
```
if fetch called like this:
```js
fetch(new Request('http://domain1'));
```
I've added the fix, which will match such calls.