### PR TITLE
Added prebrowserified build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules/
 npm-debug.log
 /es5/
+/dist/

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ it('should make a request', function (done) {
 
 ### Environment doesn't support requiring fetch-mock?
 
-- If your client-side code or tests do not use a loader that respects the browser field of package.json use `require('fetch-mock/es5/client')`. This can also be loaded directly in a script tag as `./node_modules/fetch-mock/es5/client.js` (Disclaimer: I haven't actually tried this, but it should work) 
+- If your client-side code or tests do not use a loader that respects the browser field of package.json use `require('fetch-mock/es5/client')`.
+- If your client-side tests do not run in a browserified environment, you can include the precompiled `node_modules/fetch-mock/es5/client-browserified.js` in a script tag. This loads fetch-mock into the `FetchMock` global variable.
 - For server side tests running in nodejs 0.12 or lower use `require('fetch-mock/es5/server')`
 
 ### Polyfilling fetch

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,8 +12,7 @@ module.exports = function(karma) {
 			'test/client.js': ['browserify']
 		},
 		browserify: {
-				transform: [['babelify', {	presets: ['es2015'] }]],
-				debug: true
+			debug: true
 		},
 		browsers: ['Chrome'],
 		customLaunchers: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "browser": "es5/client.js",
   "scripts": {
     "test": "make test",
-    "prepublish": "babel src --out-dir es5 --presets es2015"
+    "browserify": "browserify -s FetchMock src/client.js > es5/client-browserified.js",
+    "prepublish": "babel src --out-dir es5 --presets es2015 && npm run browserify"
   },
   "repository": {
     "type": "git",
@@ -46,5 +47,10 @@
     "mocha": "^2.2.4",
     "sinon": "^1.17.0",
     "whatwg-fetch": "^0.10.1"
+  },
+  "browserify": {
+    "transform": [
+      ["babelify", { "presets": ["es2015"] }]
+    ]
   }
 }


### PR DESCRIPTION
Now publishes a standalone pre-browserified client build to `/es5/client-browserified.js`, which loads fetch-mock into the `FetchMock` global variable.

Resolves #47 