### PR TITLE
Use locally installed version of eslint and mocha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,9 @@ test-browser:
 	./node_modules/karma/bin/karma start --single-run
 
 test-unit:
-	mocha test/server.js
+	./node_modules/.bin/mocha test/server.js
 
 lint:
-	eslint src test
+	./node_modules/.bin/eslint src test
 
 test: test-unit lint test-browser
-
-
-


### PR DESCRIPTION
Running the tests broke for me, because I didn't have eslint installed globally.