### PR TITLE
Add type param to make json stringification opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Replaces `fetch()` with a stub which records its calls, grouped by route, and op
 		* `status`: Set the response status (defaut `200`)
 		* `headers`: Set the response headers. (`object`)
 		* `throws`: If this property is present then a `Promise` rejected with the value of `throws` is returned
+		* `sendAsJson`: This property determines whether or not the request body should be JSON.stringified before being sent (defaults to true).
 	* `Function(url, opts)`: A function that is passed the url and opts `fetch()` is called with and that returns any of the responses listed above
 
 #### `restore()`

--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -38,6 +38,7 @@ function mockResponse (url, config) {
 
 	const opts = config.opts || {};
 	opts.url = url;
+	opts.sendAsJson = config.sendAsJson === undefined ? true : config.sendAsJson;
 	opts.status = config.status || 200;
 	// The ternary operator is to cope with new Headers(undefined) throwing in Chrome
 	// https://code.google.com/p/chromium/issues/detail?id=335871
@@ -45,7 +46,7 @@ function mockResponse (url, config) {
 
 	let body = config.body;
 	/*eslint-disable*/
-	if (config.body != null && typeof body === 'object') {
+	if (opts.sendAsJson && config.body != null && typeof body === 'object') {
 	/*eslint-enable*/
 		body = JSON.stringify(body);
 	}

--- a/test/client.js
+++ b/test/client.js
@@ -14,7 +14,29 @@ describe('native fetch behaviour', function () {
 		}).not.to.throw();
 		fetchMock.restore();
 	});
-})
+});
+
+describe('request types that only work in the browser', function () {
+
+	it('respond with blob', function (done) {
+		const blob = new Blob();
+		fetchMock.mock({
+			routes: {
+				name: 'route',
+				matcher: 'http://it.at.there/',
+				response: {body: blob, sendAsJson: false}
+			}
+		});
+		fetch('http://it.at.there/')
+			.then(function (res) {
+				expect(res.status).to.equal(200);
+				res.blob().then(function (blobData) {
+					expect(blobData).to.eql(blob);
+					done();
+				});
+			});
+	});
+});
 
 require('./spec')(fetchMock, window, window.Request);
 


### PR DESCRIPTION
The main goal of this PR is to allow users of this library to stub non-json or text requests. I ran into a problem where I wanted to stub a call with type='arrayBuffer' and I wasn't able to, because the body was being `JSON.stringified`. Let me know if there are any other changes you'd like to see!