### PR TITLE
Add filterCalls(), testCalls()

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,22 +41,32 @@ Clears all data recorded for `fetch()`'s calls
 
 *Note that `restore()`, `reMock()` and `reset()` are all bound to fetchMock, and can be used directly as callbacks e.g. `afterEach(fetchMock.restore)` will work just fine. There is no need for `afterEach(function () {fetchMock.restore()})`*
 
-**For the methods below `matcher`, if given, should be either the name of a route (see advanced usage below) or equal to `matcher.toString()` for any unnamed route**
+**For the methods below `name`, if given, should be either the name of a route (see advanced usage below) or equal to `matcher.toString()` for any unnamed route**
 
-#### `calls(matcher)`
-Returns an object `{matched: [], unmatched: []}` containing arrays of all calls to fetch, grouped by whether fetch-mock matched them or not. If `matcher` is specified then only calls to fetch matching that route are returned.
+#### `calls(name)`
+Returns an object `{matched: [], unmatched: []}` containing arrays of all calls to fetch, grouped by whether fetch-mock matched them or not. If `name` is specified then only calls to fetch matching that route are returned.
 
-#### `called(matcher)`
-Returns a Boolean indicating whether fetch was called and a route was matched. If `matcher` is specified it only returns `true` if that particular route was matched.
+#### `called(name)`
+Returns a Boolean indicating whether fetch was called and a route was matched. If `name` is specified it only returns `true` if that particular route was matched.
 
-#### `lastCall(matcher)`
+#### `lastCall(name)`
 Returns the arguments for the last matched call to fetch
 
-#### `lastUrl(matcher)`
+#### `lastUrl(name)`
 Returns the url for the last matched call to fetch
 
-#### `lastOptions(matcher)`
+#### `lastOptions(name)`
 Returns the options for the last matched call to fetch
+
+**In the following methods, `matcher` can be a `string`, `RegExp` or `Function(url, opts)` and will attempt to match against all calls regardless of whether they match any configured routes**
+
+#### `callsMatching(matcher)`
+Returns an object `{routed: [], unrouted: []}` containing arrays of all matching calls to fetch, grouped by whether they matched any routes or not. `routed` and `unrouted` here are analogous to `matched` and `unmatched` as returned by `calls(name)`.
+
+#### `calledMatching(matcher)`
+Returns a Boolean indicating whether fetch was called with a URL matching `matcher`.
+
+
 
 ##### Example
 

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ Returns the url for the last matched call to fetch
 #### `lastOptions(name)`
 Returns the options for the last matched call to fetch
 
-**In the following methods, `matcher` can be a `string`, `RegExp` or `Function(url, opts)` and will attempt to match against all calls regardless of whether they match any configured routes**
+**In the following methods, `matcher` can be a `string`, `RegExp` or `Function(url, opts)` and will be used to search through _all_ calls, regardless of whether they previously matched any configured routes**
 
-#### `callsMatching(matcher)`
+#### `filterCalls(matcher)`
 Returns an object `{routed: [], unrouted: []}` containing arrays of all matching calls to fetch, grouped by whether they matched any routes or not. `routed` and `unrouted` here are analogous to `matched` and `unmatched` as returned by `calls(name)`.
 
-#### `calledMatching(matcher)`
+#### `testCalls(matcher)`
 Returns a Boolean indicating whether fetch was called with a URL matching `matcher`.
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-mock",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "Mock http requests made using fetch (or isomorphic-fetch)",
   "main": "src/server.js",
   "browser": "es5/client.js",

--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -417,10 +417,10 @@ class FetchMock {
 	}
 
 	/**
-	 * callsMatching
+	 * filterCalls
 	 * Returns call history filtered by matcher. See README
 	 */
-	callsMatching (matcher) {
+	filterCalls (matcher) {
 		matcher = compileUserUrlMatcher(matcher);
 		return {
 			routed: this._matchedCalls.filter(call => matcher(call[0], call[1])),
@@ -429,10 +429,10 @@ class FetchMock {
 	}
 
 	/**
-	 * calledMatching
+	 * testCalls
 	 * Returns whether fetch has been called with a matching URL. See README
 	 */
-	calledMatching (matcher) {
+	testCalls (matcher) {
 		matcher = compileUserUrlMatcher(matcher);
 		return [this._matchedCalls, this._unmatchedCalls].some(calls => calls.some(call => matcher(call[0], call[1])));
 	}

--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -83,6 +83,55 @@ function normalizeRequest (url, options) {
 }
 
 /**
+ * compileUrlMatcher
+ * Compiles a URL matching function.
+ * @param  {String|RegExp|Function(String, Object=):Boolean} matcher
+ * @return {Function(String, Object=):Boolean}
+ */
+function compileUrlMatcher (matcher) {
+	if (typeof matcher === 'function') {
+		return matcher;
+	}
+	else if (typeof matcher === 'string') {
+
+		if (matcher.indexOf('^') === 0) {
+			const expectedUrl = matcher.substr(1);
+			return function (url) {
+				return url.indexOf(expectedUrl) === 0;
+			};
+		} else {
+			const expectedUrl = matcher;
+			return function (url) {
+				return url === expectedUrl;
+			};
+		}
+	} else if (matcher instanceof RegExp) {
+		const urlRX = matcher;
+		return function (url) {
+			return urlRX.test(url);
+		};
+	}
+	else {
+		throw new Error('URL matcher must be a function, string, or RegExp');
+	}
+}
+
+/**
+ * compileUserUrlMatcher
+ * Compiles a URL matching function that also normalizes Request objects
+ * @param  {String|RegExp|Function(String, Object=):Boolean} matcher
+ * @return {Function(String, Object=):Boolean}
+ */
+function compileUserUrlMatcher (matcher) {
+	matcher = compileUrlMatcher(matcher);
+	return function (url, options) {
+		const req = normalizeRequest(url, options);
+		return matcher(req.url, options);
+	};
+}
+
+
+/**
  * compileRoute
  * Given a route configuration object, validates the object structure and compiles
  * the object into a {name, matcher, response} triple
@@ -116,27 +165,7 @@ function compileRoute (route) {
     return !expectedMethod || expectedMethod === (method ? method.toLowerCase() : 'get');
   };
 
-	let matchUrl;
-
-	if (typeof route.matcher === 'string') {
-
-		if (route.matcher.indexOf('^') === 0) {
-			const expectedUrl = route.matcher.substr(1);
-			matchUrl = function (url) {
-				return url.indexOf(expectedUrl) === 0;
-			};
-		} else {
-			const expectedUrl = route.matcher;
-			matchUrl = function (url) {
-				return url === expectedUrl;
-			};
-		}
-	} else if (route.matcher instanceof RegExp) {
-		const urlRX = route.matcher;
-		matchUrl = function (url) {
-			return urlRX.test(url);
-		};
-	}
+	let matchUrl = compileUrlMatcher(route.matcher);
 
 	route.matcher = function (url, options) {
 		const req = normalizeRequest(url, options);
@@ -385,6 +414,27 @@ class FetchMock {
 			return !!(this._matchedCalls.length);
 		}
 		return !!(this._calls[name] && this._calls[name].length);
+	}
+
+	/**
+	 * callsMatching
+	 * Returns call history filtered by matcher. See README
+	 */
+	callsMatching (matcher) {
+		matcher = compileUserUrlMatcher(matcher);
+		return {
+			routed: this._matchedCalls.filter(call => matcher(call[0], call[1])),
+			unrouted: this._unmatchedCalls.filter(call => matcher(call[0], call[1]))
+		};
+	}
+
+	/**
+	 * calledMatching
+	 * Returns whether fetch has been called with a matching URL. See README
+	 */
+	calledMatching (matcher) {
+		matcher = compileUserUrlMatcher(matcher);
+		return [this._matchedCalls, this._unmatchedCalls].some(calls => calls.some(call => matcher(call[0], call[1])));
 	}
 }
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -407,6 +407,9 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							expect(fetchMock.calls('route2').length).to.equal(1);
 							expect(fetchMock.calls().matched.length).to.equal(2);
 							expect(fetchMock.calls().unmatched.length).to.equal(1);
+							expect(fetchMock.calledMatching('^http://it')).to.be.true;
+							expect(fetchMock.callsMatching('^http://it').routed.length).to.equal(2);
+							expect(fetchMock.callsMatching('^http://it').unrouted.length).to.equal(1);
 						});
 				});
 
@@ -429,6 +432,9 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							expect(fetchMock.calls('route1').length).to.equal(1);
 							expect(fetchMock.calls().matched.length).to.equal(1);
 							expect(fetchMock.calls('route2').length).to.equal(0);
+							expect(fetchMock.calledMatching('^http://it')).to.be.true;
+							expect(fetchMock.callsMatching('^http://it').routed.length).to.equal(1);
+							expect(fetchMock.callsMatching('^http://it').unrouted.length).to.equal(0);
 						});
 				});
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -450,7 +450,7 @@ module.exports = function (fetchMock, theGlobal, Request) {
 						});
 				});
 
-				it('have helpers to retrieve paramaters pf last call', function () {
+				it('have helpers to retrieve parameters of last call', function () {
 					fetchMock.mock({
 						routes: {
 							name: 'route',

--- a/test/spec.js
+++ b/test/spec.js
@@ -515,7 +515,7 @@ module.exports = function (fetchMock, theGlobal, Request) {
 
 			});
 			describe('call matching', function () {
-				it('match exact strings', function (done) {
+				it('match exact strings', function () {
 					fetchMock.mock({
 						routes: {
 							name: 'route',
@@ -523,7 +523,7 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							response: 'ok'
 						}
 					});
-					Promise.all([fetch('http://it.at.there/'), fetch('http://it.at.thereabouts')])
+					return Promise.all([fetch('http://it.at.there/'), fetch('http://it.at.thereabouts')])
 						.then(function () {
 							expect(fetchMock.calledMatching('route')).to.be.false;
 							expect(fetchMock.calledMatching('http://it.at.there/')).to.be.true;
@@ -531,11 +531,10 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							expect(fetchMock.callsMatching('route').routed.length).to.equal(0);
 							expect(fetchMock.callsMatching('http://it.at.there/').routed.length).to.equal(1);
 							expect(fetchMock.callsMatching('http://it.at.thereabouts').unrouted.length).to.equal(1);
-							done();
 						});
 				});
 
-				it('match when relative url', function (done) {
+				it('match when relative url', function () {
 					fetchMock.mock({
 						routes: {
 							name: 'route',
@@ -544,17 +543,16 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							response: 'ok'
 						}
 					});
-					fetch('/it.at.there/', {method: 'POST'})
+					return fetch('/it.at.there/', {method: 'POST'})
 						.then(function () {
 							expect(fetchMock.calledMatching('route')).to.be.false;
 							expect(fetchMock.calledMatching('/it.at.there/')).to.be.true;
 							expect(fetchMock.callsMatching('route').routed.length).to.equal(0);
 							expect(fetchMock.callsMatching('/it.at.there/').routed.length).to.equal(1);
-							done();
 						});
 				});
 
-				it('match when Request instance', function (done) {
+				it('match when Request instance', function () {
 					fetchMock.mock({
 						routes: {
 							name: 'route',
@@ -563,17 +561,16 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							response: 'ok'
 						}
 					});
-					fetch(new Request('http://it.at.there/', {method: 'POST'}))
+					return fetch(new Request('http://it.at.there/', {method: 'POST'}))
 						.then(function () {
 							expect(fetchMock.calledMatching('route')).to.be.false;
 							expect(fetchMock.calledMatching('http://it.at.there/')).to.be.true;
 							expect(fetchMock.callsMatching('route').routed.length).to.equal(0);
 							expect(fetchMock.callsMatching('http://it.at.there/').routed.length).to.equal(1);
-							done();
 						});
 				});
 
-				it('match strings starting with a string', function (done) {
+				it('match strings starting with a string', function () {
 					fetchMock.mock({
 						routes: {
 							name: 'route',
@@ -581,7 +578,7 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							response: 'ok'
 						}
 					});
-					Promise.all([
+					return Promise.all([
 						fetch('http://it.at.there'),
 						fetch('http://it.at.thereabouts'),
 						fetch('http://it.at.hereabouts')]
@@ -602,11 +599,10 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							expect(fetchMock.callsMatching('^http://it').unrouted.length).to.equal(1);
 							expect(fetchMock.callsMatching('^http://it.at.there').routed.length).to.equal(2);
 							expect(fetchMock.callsMatching('^http://it.at.therewego').routed.length).to.equal(0);
-							done();
 						});
 				});
 
-				it('match regular expressions', function (done) {
+				it('match regular expressions', function () {
 					fetchMock.mock({
 						routes: {
 							name: 'route',
@@ -614,7 +610,7 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							response: 'ok'
 						}
 					});
-					Promise.all([fetch('http://it.at.there/'), fetch('http://it.at.there/12345'), fetch('http://it.at.there/abcde')])
+					return Promise.all([fetch('http://it.at.there/'), fetch('http://it.at.there/12345'), fetch('http://it.at.there/abcde')])
 						.then(function () {
 							expect(fetchMock.calledMatching('route')).to.be.false;
 							expect(fetchMock.calledMatching(/http\:\/\/it\.at\.there\/\d+/)).to.be.true;
@@ -625,11 +621,10 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							expect(fetchMock.callsMatching(/http\:\/\/it\.at\.there\/[a-e]+/).routed.length).to.equal(0);
 							expect(fetchMock.callsMatching(/http\:\/\/it\.at\.there\/[a-e]+/).unrouted.length).to.equal(1);
 							expect(fetchMock.callsMatching(/http\:\/\/it\.at\.there\/[f-z]+/).routed.length).to.equal(0);
-							done();
 						});
 				});
 
-				it('match using custom functions', function (done) {
+				it('match using custom functions', function () {
 					fetchMock.mock({
 						routes: {
 							name: 'route',
@@ -639,7 +634,7 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							response: 'ok'
 						}
 					});
-					Promise.all([
+					return Promise.all([
 						fetch('http://it.at.there/logged-in', {headers:{authorized: true}}),
 						fetch('http://it.at.there/12345', {headers:{authorized: true}}),
 						fetch('http://it.at.there/logged-in')
@@ -666,7 +661,6 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							expect(fetchMock.callsMatching(function (url, opts) {
 								return url.indexOf('67890') > -1 && opts && opts.headers && opts.headers.authorized === true;
 							}).routed.length).to.equal(0);
-							done();
 						});
 				});
 			});

--- a/test/spec.js
+++ b/test/spec.js
@@ -407,9 +407,9 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							expect(fetchMock.calls('route2').length).to.equal(1);
 							expect(fetchMock.calls().matched.length).to.equal(2);
 							expect(fetchMock.calls().unmatched.length).to.equal(1);
-							expect(fetchMock.calledMatching('^http://it')).to.be.true;
-							expect(fetchMock.callsMatching('^http://it').routed.length).to.equal(2);
-							expect(fetchMock.callsMatching('^http://it').unrouted.length).to.equal(1);
+							expect(fetchMock.testCalls('^http://it')).to.be.true;
+							expect(fetchMock.filterCalls('^http://it').routed.length).to.equal(2);
+							expect(fetchMock.filterCalls('^http://it').unrouted.length).to.equal(1);
 						});
 				});
 
@@ -432,9 +432,9 @@ module.exports = function (fetchMock, theGlobal, Request) {
 							expect(fetchMock.calls('route1').length).to.equal(1);
 							expect(fetchMock.calls().matched.length).to.equal(1);
 							expect(fetchMock.calls('route2').length).to.equal(0);
-							expect(fetchMock.calledMatching('^http://it')).to.be.true;
-							expect(fetchMock.callsMatching('^http://it').routed.length).to.equal(1);
-							expect(fetchMock.callsMatching('^http://it').unrouted.length).to.equal(0);
+							expect(fetchMock.testCalls('^http://it')).to.be.true;
+							expect(fetchMock.filterCalls('^http://it').routed.length).to.equal(1);
+							expect(fetchMock.filterCalls('^http://it').unrouted.length).to.equal(0);
 						});
 				});
 
@@ -531,12 +531,12 @@ module.exports = function (fetchMock, theGlobal, Request) {
 					});
 					return Promise.all([fetch('http://it.at.there/'), fetch('http://it.at.thereabouts')])
 						.then(function () {
-							expect(fetchMock.calledMatching('route')).to.be.false;
-							expect(fetchMock.calledMatching('http://it.at.there/')).to.be.true;
-							expect(fetchMock.calledMatching('http://it.at.thereabouts')).to.be.true;
-							expect(fetchMock.callsMatching('route').routed.length).to.equal(0);
-							expect(fetchMock.callsMatching('http://it.at.there/').routed.length).to.equal(1);
-							expect(fetchMock.callsMatching('http://it.at.thereabouts').unrouted.length).to.equal(1);
+							expect(fetchMock.testCalls('route')).to.be.false;
+							expect(fetchMock.testCalls('http://it.at.there/')).to.be.true;
+							expect(fetchMock.testCalls('http://it.at.thereabouts')).to.be.true;
+							expect(fetchMock.filterCalls('route').routed.length).to.equal(0);
+							expect(fetchMock.filterCalls('http://it.at.there/').routed.length).to.equal(1);
+							expect(fetchMock.filterCalls('http://it.at.thereabouts').unrouted.length).to.equal(1);
 						});
 				});
 
@@ -551,10 +551,10 @@ module.exports = function (fetchMock, theGlobal, Request) {
 					});
 					return fetch('/it.at.there/', {method: 'POST'})
 						.then(function () {
-							expect(fetchMock.calledMatching('route')).to.be.false;
-							expect(fetchMock.calledMatching('/it.at.there/')).to.be.true;
-							expect(fetchMock.callsMatching('route').routed.length).to.equal(0);
-							expect(fetchMock.callsMatching('/it.at.there/').routed.length).to.equal(1);
+							expect(fetchMock.testCalls('route')).to.be.false;
+							expect(fetchMock.testCalls('/it.at.there/')).to.be.true;
+							expect(fetchMock.filterCalls('route').routed.length).to.equal(0);
+							expect(fetchMock.filterCalls('/it.at.there/').routed.length).to.equal(1);
 						});
 				});
 
@@ -569,10 +569,10 @@ module.exports = function (fetchMock, theGlobal, Request) {
 					});
 					return fetch(new Request('http://it.at.there/', {method: 'POST'}))
 						.then(function () {
-							expect(fetchMock.calledMatching('route')).to.be.false;
-							expect(fetchMock.calledMatching('http://it.at.there/')).to.be.true;
-							expect(fetchMock.callsMatching('route').routed.length).to.equal(0);
-							expect(fetchMock.callsMatching('http://it.at.there/').routed.length).to.equal(1);
+							expect(fetchMock.testCalls('route')).to.be.false;
+							expect(fetchMock.testCalls('http://it.at.there/')).to.be.true;
+							expect(fetchMock.filterCalls('route').routed.length).to.equal(0);
+							expect(fetchMock.filterCalls('http://it.at.there/').routed.length).to.equal(1);
 						});
 				});
 
@@ -590,21 +590,21 @@ module.exports = function (fetchMock, theGlobal, Request) {
 						fetch('http://it.at.hereabouts')]
 					)
 						.then(function () {
-							expect(fetchMock.calledMatching('route')).to.be.false;
-							expect(fetchMock.calledMatching('http://it.at.there')).to.be.true;
-							expect(fetchMock.calledMatching('http://it.at.thereabouts')).to.be.true;
-							expect(fetchMock.calledMatching('http://it.at.hereabouts')).to.be.true;
-							expect(fetchMock.calledMatching('^http://it')).to.be.true;
-							expect(fetchMock.calledMatching('^http://it.at.there')).to.be.true;
-							expect(fetchMock.calledMatching('^http://it.at.therewego')).to.be.false;
-							expect(fetchMock.callsMatching('route').routed.length).to.equal(0);
-							expect(fetchMock.callsMatching('http://it.at.there').routed.length).to.equal(1);
-							expect(fetchMock.callsMatching('http://it.at.thereabouts').routed.length).to.equal(1);
-							expect(fetchMock.callsMatching('http://it.at.hereabouts').unrouted.length).to.equal(1);
-							expect(fetchMock.callsMatching('^http://it').routed.length).to.equal(2);
-							expect(fetchMock.callsMatching('^http://it').unrouted.length).to.equal(1);
-							expect(fetchMock.callsMatching('^http://it.at.there').routed.length).to.equal(2);
-							expect(fetchMock.callsMatching('^http://it.at.therewego').routed.length).to.equal(0);
+							expect(fetchMock.testCalls('route')).to.be.false;
+							expect(fetchMock.testCalls('http://it.at.there')).to.be.true;
+							expect(fetchMock.testCalls('http://it.at.thereabouts')).to.be.true;
+							expect(fetchMock.testCalls('http://it.at.hereabouts')).to.be.true;
+							expect(fetchMock.testCalls('^http://it')).to.be.true;
+							expect(fetchMock.testCalls('^http://it.at.there')).to.be.true;
+							expect(fetchMock.testCalls('^http://it.at.therewego')).to.be.false;
+							expect(fetchMock.filterCalls('route').routed.length).to.equal(0);
+							expect(fetchMock.filterCalls('http://it.at.there').routed.length).to.equal(1);
+							expect(fetchMock.filterCalls('http://it.at.thereabouts').routed.length).to.equal(1);
+							expect(fetchMock.filterCalls('http://it.at.hereabouts').unrouted.length).to.equal(1);
+							expect(fetchMock.filterCalls('^http://it').routed.length).to.equal(2);
+							expect(fetchMock.filterCalls('^http://it').unrouted.length).to.equal(1);
+							expect(fetchMock.filterCalls('^http://it.at.there').routed.length).to.equal(2);
+							expect(fetchMock.filterCalls('^http://it.at.therewego').routed.length).to.equal(0);
 						});
 				});
 
@@ -618,15 +618,15 @@ module.exports = function (fetchMock, theGlobal, Request) {
 					});
 					return Promise.all([fetch('http://it.at.there/'), fetch('http://it.at.there/12345'), fetch('http://it.at.there/abcde')])
 						.then(function () {
-							expect(fetchMock.calledMatching('route')).to.be.false;
-							expect(fetchMock.calledMatching(/http\:\/\/it\.at\.there\/\d+/)).to.be.true;
-							expect(fetchMock.calledMatching(/http\:\/\/it\.at\.there\/[a-e]+/)).to.be.true;
-							expect(fetchMock.calledMatching(/http\:\/\/it\.at\.there\/[f-z]+/)).to.be.false;
-							expect(fetchMock.callsMatching('route').routed.length).to.equal(0);
-							expect(fetchMock.callsMatching(/http\:\/\/it\.at\.there\/\d+/).routed.length).to.equal(1);
-							expect(fetchMock.callsMatching(/http\:\/\/it\.at\.there\/[a-e]+/).routed.length).to.equal(0);
-							expect(fetchMock.callsMatching(/http\:\/\/it\.at\.there\/[a-e]+/).unrouted.length).to.equal(1);
-							expect(fetchMock.callsMatching(/http\:\/\/it\.at\.there\/[f-z]+/).routed.length).to.equal(0);
+							expect(fetchMock.testCalls('route')).to.be.false;
+							expect(fetchMock.testCalls(/http\:\/\/it\.at\.there\/\d+/)).to.be.true;
+							expect(fetchMock.testCalls(/http\:\/\/it\.at\.there\/[a-e]+/)).to.be.true;
+							expect(fetchMock.testCalls(/http\:\/\/it\.at\.there\/[f-z]+/)).to.be.false;
+							expect(fetchMock.filterCalls('route').routed.length).to.equal(0);
+							expect(fetchMock.filterCalls(/http\:\/\/it\.at\.there\/\d+/).routed.length).to.equal(1);
+							expect(fetchMock.filterCalls(/http\:\/\/it\.at\.there\/[a-e]+/).routed.length).to.equal(0);
+							expect(fetchMock.filterCalls(/http\:\/\/it\.at\.there\/[a-e]+/).unrouted.length).to.equal(1);
+							expect(fetchMock.filterCalls(/http\:\/\/it\.at\.there\/[f-z]+/).routed.length).to.equal(0);
 						});
 				});
 
@@ -646,25 +646,25 @@ module.exports = function (fetchMock, theGlobal, Request) {
 						fetch('http://it.at.there/logged-in')
 					])
 						.then(function () {
-							expect(fetchMock.calledMatching('route')).to.be.false;
-							expect(fetchMock.calledMatching(function (url, opts) {
+							expect(fetchMock.testCalls('route')).to.be.false;
+							expect(fetchMock.testCalls(function (url, opts) {
 								return url.indexOf('logged-in') > -1 && opts && opts.headers && opts.headers.authorized === true;
 							})).to.be.true;
-							expect(fetchMock.calledMatching(function (url, opts) {
+							expect(fetchMock.testCalls(function (url, opts) {
 								return url.indexOf('12345') > -1 && opts && opts.headers && opts.headers.authorized === true;
 							})).to.be.true;
-							expect(fetchMock.calledMatching(function (url, opts) {
+							expect(fetchMock.testCalls(function (url, opts) {
 								return url.indexOf('67890') > -1 && opts && opts.headers && opts.headers.authorized === true;
 							})).to.be.false;
 
-							expect(fetchMock.callsMatching('route').routed.length).to.equal(0);							
-							expect(fetchMock.callsMatching(function (url, opts) {
+							expect(fetchMock.filterCalls('route').routed.length).to.equal(0);							
+							expect(fetchMock.filterCalls(function (url, opts) {
 								return url.indexOf('logged-in') > -1 && opts && opts.headers && opts.headers.authorized === true;
 							}).routed.length).to.equal(1);
-							expect(fetchMock.callsMatching(function (url, opts) {
+							expect(fetchMock.filterCalls(function (url, opts) {
 								return url.indexOf('12345') > -1 && opts && opts.headers && opts.headers.authorized === true;
 							}).unrouted.length).to.equal(1);
-							expect(fetchMock.callsMatching(function (url, opts) {
+							expect(fetchMock.filterCalls(function (url, opts) {
 								return url.indexOf('67890') > -1 && opts && opts.headers && opts.headers.authorized === true;
 							}).routed.length).to.equal(0);
 						});


### PR DESCRIPTION
This combines a proposed implementation of #88 with a doc fix for #87 which originally prompted me to come up with this API. URL matcher compilation was refactored so it could be shared between `compileRoute` and the new methods.

Notes:
- I originally called these functions `callsMatched()` and `calledMatched()`, but in light of @wheresrhys's concerns, I now think it would be better to distance them from `calls()` and `called()` to reduce confusion, hence their new names.
- This bakes `normalizeRequest` into the handling of matchers, in the new methods only (see `compileUserUrlMatcher`). This may or may not be desired but was the quickest way to get roughly what I wanted here.

EDIT: I've rewritten most of this description for clarity. Further discussion of the separate motivations for this PR probably belongs separately in issues #87 and #88.
