### PR TITLE
Replace Object.assign with an inline helper when transpiling to ES5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-object-assign"
+  ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,0 @@
-{
-  "plugins": [
-    "transform-object-assign"
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "make test",
     "browserify": "browserify -s fetchMock src/client.js > es5/client-browserified.js",
-    "prepublish": "babel src --out-dir es5 --presets es2015 && npm run browserify"
+    "prepublish": "babel src --out-dir es5 --plugins transform-object-assign --presets es2015 && npm run browserify"
   },
   "repository": {
     "type": "git",
@@ -55,6 +55,9 @@
       [
         "babelify",
         {
+          "plugins": [
+            "transform-object-assign"
+          ],
           "presets": [
             "es2015"
           ]

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "babel": "^6.0.15",
     "babel-cli": "^6.1.2",
+    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.1.2",
     "babelify": "^7.2.0",
     "browserify": "^12.0.0",


### PR DESCRIPTION
Fixes #115.