### PR TITLE
Remove browserify field from package.json and change build/publish path

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    "transform-object-assign"
+  ]
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,7 +12,8 @@ module.exports = function(karma) {
 			'test/client.js': ['browserify']
 		},
 		browserify: {
-			debug: true
+			debug: true,
+			transform: ['babelify']
 		},
 		browsers: ['Chrome'],
 		customLaunchers: {

--- a/package.json
+++ b/package.json
@@ -2,12 +2,17 @@
   "name": "fetch-mock",
   "version": "5.1.0",
   "description": "Mock http requests made using fetch (or isomorphic-fetch)",
-  "main": "src/server.js",
+  "files": [
+    "*.md",
+    "es5"
+  ],
+  "main": "es5/server.js",
   "browser": "es5/client.js",
   "scripts": {
+    "build": "rimraf es5 && babel ./src -d es5 && npm run browserify",
     "test": "make test",
-    "browserify": "browserify -s fetchMock src/client.js > es5/client-browserified.js",
-    "prepublish": "babel src --out-dir es5 --plugins transform-object-assign --presets es2015 && npm run browserify"
+    "browserify": "browserify -s fetchMock src/client.js -t [ babelify ] > es5/client-browserified.js",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -49,22 +54,8 @@
     "karma-phantomjs-launcher": "^0.2.1",
     "mocha": "^2.2.4",
     "mockery": "^1.4.0",
+    "rimraf": "^2.5.4",
     "sinon": "^1.17.0",
     "whatwg-fetch": "^0.10.1"
-  },
-  "browserify": {
-    "transform": [
-      [
-        "babelify",
-        {
-          "plugins": [
-            "transform-object-assign"
-          ],
-          "presets": [
-            "es2015"
-          ]
-        }
-      ]
-    ]
   }
 }


### PR DESCRIPTION
I was unable to use this package in my environment. My setup is based on browserify and Typescript. When I tried to bundle my test files where I required('fetch-mock') browserify looked up the transform field and tried to load babelify. As soon as I removed the browserify field from package.json everything works fine. 

To compensate the changes a added the commonly used .babelrc file with the same settings as in package.json and added the babelify transform to the browserify command line arguments and in the karma config. 

Furthermore I changed the main field to point to the already transpiled server.js file in the es5 folder.

Next I added the files field to package.json. This lists all files that should be included when publishing the package to npm. I don't think you need to publish more then the *.md and the transpiled (& bundled) *.js files.

And for ease of use during dev I added also a npm run build command.

Tests: Chrome 52.0.2743 (Linux 0.0.0): Executed 61 of 61 SUCCESS (0.191 secs / 0.089 secs)