### PR TITLE
Fixes bug in interaction with babel-transform-runtime - Fixes #132

### DIFF
--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -241,7 +241,8 @@ class FetchMock {
 			response = response (url, opts);
 		}
 
-		if (response instanceof Promise) {
+		// Checks if the response is a promise without using Promise builtin
+		if (typeof response.then === 'function') {
 			return response.then(response => this.mockResponse(url, response, opts))
 		} else {
 			return this.mockResponse(url, response, opts)


### PR DESCRIPTION
Removes reference to Promise builtin so that check for promise works
even when the Project is using a non global Promise polyfill
(Like what happens with babel-transform-runtime)

