### PR TITLE
support for non native promise implementations

### DIFF
--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -245,7 +245,7 @@ class FetchMock {
 			response = response (url, opts);
 		}
 
-		if (response instanceof Promise) {
+		if (typeof response.then === 'function') {
 			return response.then(response => this.mockResponse(url, response, opts))
 		} else {
 			return this.mockResponse(url, response, opts)

--- a/test/spec.js
+++ b/test/spec.js
@@ -885,6 +885,19 @@ e.g. {"body": {"status: "registered"}}`);
 				expect(realFetch).to.equal(theGlobal.fetch);
 			})
 
+			it('should allow non native Promises as responses', () => {
+				const stub = sinon.spy(() => Promise.resolve(new Response('', {status: 203})));
+				fetchMock.mock(/.*/, {
+				   then: stub
+				})
+				return fetch('http://thing.place')
+					.then(res => {
+						expect(stub.calledOnce).to.be.true
+						expect(res.status).to.equal(203);
+						fetchMock.restore();
+					})
+			})
+
 		})
 	});
 }


### PR DESCRIPTION
Specifically to deal with babelified code having polyfills imposed on it. Fixes https://github.com/wheresrhys/fetch-mock/issues/132