### PR TITLE
Allow passing a custom promise implementation to sandbox()

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ fetchMock
 ##### `spy()`
 Similar to `catch()`, this records the call history of unmatched calls, but instead of responding with a stubbed response, the request is passed through to native `fetch()` and is allowed to communicate over the network.
 
-##### `sandbox(promise)` *experimental*
+##### `sandbox(Promise)` *experimental*
 This returns a drop-in mock for fetch which can be passed to other mocking libraries. It implements the full fetch-mock api and maintains its own state independent of other instances, so tests can be run in parallel. e.g.
 
 ```

--- a/README.md
+++ b/README.md
@@ -122,12 +122,14 @@ fetchMock
 ##### `spy()`
 Similar to `catch()`, this records the call history of unmatched calls, but instead of responding with a stubbed response, the request is passed through to native `fetch()` and is allowed to communicate over the network.
 
-##### `sandbox()` *experimental*
+##### `sandbox(promise)` *experimental*
 This returns a drop-in mock for fetch which can be passed to other mocking libraries. It implements the full fetch-mock api and maintains its own state independent of other instances, so tests can be run in parallel. e.g.
 
 ```
 	fetchMock.sandbox().mock('http://domain.com', 200)
 ```
+
+`sandbox()` can optionally be passed a custom promise implementation. If not provided, the `Promise` global is used.
 
 ##### `restore()`
 Chainable method that restores `fetch()` to its unstubbed state and clears all data recorded for its calls.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.1.2",
     "babelify": "^7.3.0",
+    "bluebird": "^3.4.6",
     "browserify": "^13.1.0",
     "chai": "^2.3.0",
     "eslint": "^1.10.3",

--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -128,7 +128,7 @@ FetchMock.prototype.addRoute = function (route) {
 
 
 FetchMock.prototype.mockResponse = function (url, responseConfig, fetchOpts) {
-	let Promise = this.fetchMock.promise || FetchMock.global.Promise;
+	let Promise = this.fetchMock.Promise || FetchMock.global.Promise;
 
 	// It seems odd to call this in here even though it's already called within fetchMock
 	// It's to handle the fact that because we want to support making it very easy to add a
@@ -271,7 +271,7 @@ FetchMock.setGlobals = function (globals) {
 	Object.assign(FetchMock, globals)
 }
 
-FetchMock.prototype.sandbox = function (promise) {
+FetchMock.prototype.sandbox = function (Promise) {
 	if (this.routes.length || this.fallbackResponse) {
 		throw new Error('.sandbox() can only be called on fetch-mock instances that don\'t have routes configured already')
 	}
@@ -283,7 +283,7 @@ FetchMock.prototype.sandbox = function (promise) {
 	);
 	instance.fetchMock.bindMethods();
 	instance.fetchMock.isSandbox = true;
-	instance.fetchMock.promise = promise;
+	instance.fetchMock.Promise = Promise;
 	this.restore();
 	return instance.fetchMock;
 };

--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -128,6 +128,8 @@ FetchMock.prototype.addRoute = function (route) {
 
 
 FetchMock.prototype.mockResponse = function (url, responseConfig, fetchOpts) {
+	let Promise = this.fetchMock.promise || FetchMock.global.Promise;
+
 	// It seems odd to call this in here even though it's already called within fetchMock
 	// It's to handle the fact that because we want to support making it very easy to add a
 	// delay to any sort of response (including responses which are defined with a function)
@@ -269,7 +271,7 @@ FetchMock.setGlobals = function (globals) {
 	Object.assign(FetchMock, globals)
 }
 
-FetchMock.prototype.sandbox = function () {
+FetchMock.prototype.sandbox = function (promise) {
 	if (this.routes.length || this.fallbackResponse) {
 		throw new Error('.sandbox() can only be called on fetch-mock instances that don\'t have routes configured already')
 	}
@@ -281,8 +283,9 @@ FetchMock.prototype.sandbox = function () {
 	);
 	instance.fetchMock.bindMethods();
 	instance.fetchMock.isSandbox = true;
+	instance.fetchMock.promise = promise;
 	this.restore();
-	return instance.fetchMock
+	return instance.fetchMock;
 };
 
 ['get','post','put','delete','head', 'patch']

--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -80,6 +80,7 @@ FetchMock.prototype.spy = function () {
 }
 
 FetchMock.prototype.fetchMock = function (url, opts) {
+	const Promise = this.fetchMock.Promise || FetchMock.global.Promise;
 	let response = this.router(url, opts);
 
 	if (!response) {
@@ -98,9 +99,10 @@ FetchMock.prototype.fetchMock = function (url, opts) {
 	}
 
 	if (typeof response.then === 'function') {
-		return response.then(response => this.mockResponse(url, response, opts))
+		let responsePromise = response.then(response => this.mockResponse(url, response, opts));
+		return Promise.resolve(responsePromise); // Ensure Promise is always our implementation.
 	} else {
-		return this.mockResponse(url, response, opts)
+		return this.mockResponse(url, response, opts);
 	}
 
 }
@@ -128,7 +130,7 @@ FetchMock.prototype.addRoute = function (route) {
 
 
 FetchMock.prototype.mockResponse = function (url, responseConfig, fetchOpts) {
-	let Promise = this.fetchMock.Promise || FetchMock.global.Promise;
+	const Promise = this.fetchMock.Promise || FetchMock.global.Promise;
 
 	// It seems odd to call this in here even though it's already called within fetchMock
 	// It's to handle the fact that because we want to support making it very easy to add a

--- a/test/spec.js
+++ b/test/spec.js
@@ -1122,10 +1122,9 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 					.sandbox()
 					.mock('http://example.com', GlobalPromise.resolve(200));
 
-				return sbx('http://example.com')
-					.then(res => {
-						expect(res.status).to.equal(200);
-					});
+				const responsePromise = sbx('http://example.com')
+				expect(responsePromise).to.be.instanceof(GlobalPromise);
+				return responsePromise.then(res => expect(res.status).to.equal(200));
 			});
 
 			it('works with custom promise responses when using the global promise', () => {
@@ -1133,10 +1132,9 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 					.sandbox()
 					.mock('http://example.com', BluebirdPromise.resolve(200));
 
-				return sbx('http://example.com')
-					.then(res => {
-						expect(res.status).to.equal(200);
-					});
+				const responsePromise = sbx('http://example.com')
+				expect(responsePromise).to.be.instanceof(GlobalPromise);
+				return responsePromise.then(res => expect(res.status).to.equal(200));
 			});
 
 			it('works with global promise responses when a custom promise is used', () => {
@@ -1144,10 +1142,9 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 					.sandbox(BluebirdPromise)
 					.mock('http://example.com', GlobalPromise.resolve(200));
 
-				return sbx('http://example.com')
-					.then(res => {
-						expect(res.status).to.equal(200);
-					});
+				const responsePromise = sbx('http://example.com')
+				expect(responsePromise).to.be.instanceof(BluebirdPromise);
+				return responsePromise.then(res => expect(res.status).to.equal(200));
 			});
 
 			it('works with custom promise responses when a custom promise is used', () => {
@@ -1155,10 +1152,9 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 					.sandbox(BluebirdPromise)
 					.mock('http://example.com', BluebirdPromise.resolve(200));
 
-				return sbx('http://example.com')
-					.then(res => {
-						expect(res.status).to.equal(200);
-					});
+				const responsePromise = sbx('http://example.com')
+				expect(responsePromise).to.be.instanceof(BluebirdPromise);
+				return responsePromise.then(res => expect(res.status).to.equal(200));
 			});
 
 		})

--- a/test/spec.js
+++ b/test/spec.js
@@ -2,6 +2,9 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 
+const BluebirdPromise = require('bluebird');
+const GlobalPromise = Promise;
+
 module.exports = (fetchMock, theGlobal, Request, Response) => {
 
 	describe('fetch-mock', () => {
@@ -1093,12 +1096,25 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 			});
 
 			it('takes an optional Promise to use', () => {
-				const BluebirdPromise = require('bluebird');
 				const sbx = fetchMock
 					.sandbox(BluebirdPromise)
 					.mock('http://example.com', 200);
 
 				expect(sbx('http://example.com')).to.be.instanceof(BluebirdPromise);
+			});
+
+			it('doesn\'t change the global promise', () => {
+				fetchMock.sandbox(BluebirdPromise);
+				expect(fetch('http://example.com')).to.be.instanceof(GlobalPromise);
+			});
+
+			it('doesn\'t change the promise used by other sandboxes', () => {
+				fetchMock.sandbox(BluebirdPromise);
+				const sbx = fetchMock
+					.sandbox()
+					.mock('http://example.com', 200);
+
+				expect(sbx('http://example.com')).to.be.instanceof(GlobalPromise);
 			});
 
 		})

--- a/test/spec.js
+++ b/test/spec.js
@@ -1095,7 +1095,7 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 					})
 			});
 
-			it('takes an optional Promise to use', () => {
+			it('takes an optional promise to use', () => {
 				const sbx = fetchMock
 					.sandbox(BluebirdPromise)
 					.mock('http://example.com', 200);
@@ -1103,18 +1103,62 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 				expect(sbx('http://example.com')).to.be.instanceof(BluebirdPromise);
 			});
 
-			it('doesn\'t change the global promise', () => {
+			it('doesn\'t interfere with the global promise', () => {
 				fetchMock.sandbox(BluebirdPromise);
 				expect(fetch('http://example.com')).to.be.instanceof(GlobalPromise);
 			});
 
-			it('doesn\'t change the promise used by other sandboxes', () => {
+			it('doesn\'t interfere with the promise used by other sandboxes', () => {
 				fetchMock.sandbox(BluebirdPromise);
 				const sbx = fetchMock
 					.sandbox()
 					.mock('http://example.com', 200);
 
 				expect(sbx('http://example.com')).to.be.instanceof(GlobalPromise);
+			});
+
+			it('works with global promise responses when using the global promise', () => {
+				const sbx = fetchMock
+					.sandbox()
+					.mock('http://example.com', GlobalPromise.resolve(200));
+
+				return sbx('http://example.com')
+					.then(res => {
+						expect(res.status).to.equal(200);
+					});
+			});
+
+			it('works with custom promise responses when using the global promise', () => {
+				const sbx = fetchMock
+					.sandbox()
+					.mock('http://example.com', BluebirdPromise.resolve(200));
+
+				return sbx('http://example.com')
+					.then(res => {
+						expect(res.status).to.equal(200);
+					});
+			});
+
+			it('works with global promise responses when a custom promise is used', () => {
+				const sbx = fetchMock
+					.sandbox(BluebirdPromise)
+					.mock('http://example.com', GlobalPromise.resolve(200));
+
+				return sbx('http://example.com')
+					.then(res => {
+						expect(res.status).to.equal(200);
+					});
+			});
+
+			it('works with custom promise responses when a custom promise is used', () => {
+				const sbx = fetchMock
+					.sandbox(BluebirdPromise)
+					.mock('http://example.com', BluebirdPromise.resolve(200));
+
+				return sbx('http://example.com')
+					.then(res => {
+						expect(res.status).to.equal(200);
+					});
 			});
 
 		})

--- a/test/spec.js
+++ b/test/spec.js
@@ -1092,6 +1092,15 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 					})
 			});
 
+			it('takes an optional Promise to use', () => {
+				const BluebirdPromise = require('bluebird');
+				const sbx = fetchMock
+					.sandbox(BluebirdPromise)
+					.mock('http://example.com', 200);
+
+				expect(sbx('http://example.com')).to.be.instanceof(BluebirdPromise);
+			});
+
 		})
 
 		describe('regressions', () => {


### PR DESCRIPTION
This fixes #78.