### PR TITLE
added setImplementations method to use custom fetch utility classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ Returns the options for the last matched call to fetch
 Set some global config options, which include
 * `sendAsJson` [default `true`] - by default fetchMock will convert objects to JSON before sending. This is overrideable fro each call but for some scenarios e.g. when dealing with a lot of array buffers, it can be useful to default to `false`
 
+##### `setImplementations(opts)`
+When using non global fetch (e.g. a ponyfill) or an alternatice Promise implementation, this will configure fetch-mock to use your chosen implementations. `opts` is an object with one or more of the following properties: `Headers`,`Request`,`Response`,`Promise`. Note that `setImplementations(require('fetch-ponyfill'))` will configure fetch-mock to use all of fetch-ponyfill's classes. 
+
 ## Troubleshooting and alternative installation
 
 ### `fetch` is assigned to a local variable, not a global

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Set some global config options, which include
 * `sendAsJson` [default `true`] - by default fetchMock will convert objects to JSON before sending. This is overrideable fro each call but for some scenarios e.g. when dealing with a lot of array buffers, it can be useful to default to `false`
 
 ##### `setImplementations(opts)`
-When using non global fetch (e.g. a ponyfill) or an alternatice Promise implementation, this will configure fetch-mock to use your chosen implementations. `opts` is an object with one or more of the following properties: `Headers`,`Request`,`Response`,`Promise`. Note that `setImplementations(require('fetch-ponyfill'))` will configure fetch-mock to use all of fetch-ponyfill's classes. 
+When using non global fetch (e.g. a ponyfill) or an alternative Promise implementation, this will configure fetch-mock to use your chosen implementations. `opts` is an object with one or more of the following properties: `Headers`,`Request`,`Response`,`Promise`. Note that `setImplementations(require('fetch-ponyfill'))` will configure fetch-mock to use all of fetch-ponyfill's classes. 
 
 ## Troubleshooting and alternative installation
 

--- a/src/client.js
+++ b/src/client.js
@@ -4,12 +4,14 @@ const FetchMock = require('./fetch-mock');
 const statusTextMap = require('./status-text');
 const theGlobal = typeof window !== 'undefined' ? window : self;
 
-FetchMock.setGlobals({
-	global: theGlobal,
+FetchMock.global = theGlobal;
+FetchMock.statusTextMap = statusTextMap;
+
+FetchMock.setImplementations({
+	Promise: Promise,
 	Request: theGlobal.Request,
 	Response: theGlobal.Response,
-	Headers: theGlobal.Headers,
-	statusTextMap: statusTextMap
+	Headers: theGlobal.Headers
 });
 
 module.exports = new FetchMock()

--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -80,7 +80,7 @@ FetchMock.prototype.spy = function () {
 }
 
 FetchMock.prototype.fetchMock = function (url, opts) {
-	const Promise = this.Promise || FetchMock.global.Promise;
+	const Promise = this.Promise || FetchMock.Promise;
 	let response = this.router(url, opts);
 
 	if (!response) {
@@ -130,7 +130,7 @@ FetchMock.prototype.addRoute = function (route) {
 
 
 FetchMock.prototype.mockResponse = function (url, responseConfig, fetchOpts) {
-	const Promise = this.Promise || FetchMock.global.Promise;
+	const Promise = this.Promise || FetchMock.Promise;
 
 	// It seems odd to call this in here even though it's already called within fetchMock
 	// It's to handle the fact that because we want to support making it very easy to add a
@@ -269,8 +269,11 @@ FetchMock.prototype.configure = function (opts) {
 	Object.assign(FetchMock.config, opts);
 }
 
-FetchMock.setGlobals = function (globals) {
-	Object.assign(FetchMock, globals)
+FetchMock.setImplementations = FetchMock.prototype.setImplementations = function (implementations) {
+	FetchMock.Headers = implementations.Headers || FetchMock.Headers;
+	FetchMock.Request = implementations.Request || FetchMock.Request;
+	FetchMock.Response = implementations.Response || FetchMock.Response;
+	FetchMock.Promise = implementations.Promise || FetchMock.Promise;
 }
 
 FetchMock.prototype.sandbox = function (Promise) {
@@ -295,7 +298,9 @@ FetchMock.prototype.sandbox = function (Promise) {
 	functionInstance.bindMethods();
 	boundMock = functionInstance.fetchMock;
 	functionInstance.isSandbox = true;
-	functionInstance.Promise = Promise;
+	if (Promise) {
+		functionInstance.Promise = Promise;
+	}
 
 	return functionInstance;
 };

--- a/src/server.js
+++ b/src/server.js
@@ -7,13 +7,15 @@ const stream = require('stream');
 const FetchMock = require('./fetch-mock');
 const http = require('http');
 
-FetchMock.setGlobals({
-	global: global,
+FetchMock.global = global;
+FetchMock.statusTextMap = http.STATUS_CODES;
+FetchMock.stream = stream;
+
+FetchMock.setImplementations({
+	Promise: Promise,
 	Request: Request,
 	Response: Response,
-	Headers: Headers,
-	stream: stream,
-	statusTextMap: http.STATUS_CODES
+	Headers: Headers
 });
 
 module.exports = new FetchMock()


### PR DESCRIPTION
@pimterry it'd be good if you could try this out instead of the hack mentioned in https://github.com/wheresrhys/fetch-mock/issues/158. The tests may not comprehensively test all the paths where Request/Response/Headers are used, so I will add more tests if you uncover any failures when using in your tests