### PR TITLE
Don't fail if no Promise global is available in the browser

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -8,7 +8,7 @@ FetchMock.global = theGlobal;
 FetchMock.statusTextMap = statusTextMap;
 
 FetchMock.setImplementations({
-	Promise: Promise,
+	Promise: theGlobal.Promise,
 	Request: theGlobal.Request,
 	Response: theGlobal.Response,
 	Headers: theGlobal.Headers


### PR DESCRIPTION
Nice and easy fix for #166. In real browsers this shouldn't change behaviour at all, but in Phantom it means this doesn't throw an error immediately, and `Promise` is instead just undefined and can later be set correctly.