### PR TITLE
Add failing test cases for usage of custom headers

### DIFF
--- a/src/compile-route.js
+++ b/src/compile-route.js
@@ -1,6 +1,7 @@
 'use strict';
 const glob = require('glob-to-regexp')
 const express = require('path-to-regexp');
+const Headers = require('node-fetch').Headers;
 
 const stringMatchers = {
 	begin: targetString => {
@@ -27,6 +28,11 @@ function getHeaderMatcher (expectedHeaders) {
 		if (!headers) {
 			headers = {};
 		}
+
+		if (headers instanceof Headers) {
+			headers = headers.raw();
+		}
+
 		const lowerCaseHeaders = Object.keys(headers).reduce((obj, k) => {
 			obj[k.toLowerCase()] = headers[k]
 			return obj;

--- a/src/compile-route.js
+++ b/src/compile-route.js
@@ -37,10 +37,37 @@ function getHeaderMatcher (expectedHeaders) {
 			obj[k.toLowerCase()] = headers[k]
 			return obj;
 		}, {});
+
 		return expectation.every(header => {
-			return lowerCaseHeaders[header.key] === header.val;
+			return areHeadersEqual(lowerCaseHeaders, header);
 		})
 	}
+}
+
+function areHeadersEqual (currentHeader, expectedHeader) {
+    const {key, val} = expectedHeader;
+    const currentHeaderValue = (Array.isArray(currentHeader[key])) ? currentHeader[key] : [currentHeader[key]];
+    const expectedHeaderValue = (Array.isArray(val)) ? val : [val];
+
+    if (currentHeaderValue === expectedHeaderValue) {
+		return true;
+    }
+
+    if (!currentHeaderValue || !expectedHeaderValue) {
+		return false;
+	}
+
+    if (currentHeaderValue.length !== expectedHeaderValue.length) {
+		return false;
+    }
+
+    for (let i = 0; i < currentHeaderValue.length; ++i) {
+        if (currentHeaderValue[i] !== expectedHeaderValue[i]) {
+			return false;
+        }
+    }
+
+    return true;
 }
 
 function normalizeRequest (url, options, Request) {

--- a/src/compile-route.js
+++ b/src/compile-route.js
@@ -45,7 +45,8 @@ function getHeaderMatcher (expectedHeaders) {
 }
 
 function areHeadersEqual (currentHeader, expectedHeader) {
-    const {key, val} = expectedHeader;
+    const key = expectedHeader.key;
+    const val = expectedHeader.val;
     const currentHeaderValue = (Array.isArray(currentHeader[key])) ? currentHeader[key] : [currentHeader[key]];
     const expectedHeaderValue = (Array.isArray(val)) ? val : [val];
 

--- a/src/compile-route.js
+++ b/src/compile-route.js
@@ -50,14 +50,6 @@ function areHeadersEqual (currentHeader, expectedHeader) {
     const currentHeaderValue = (Array.isArray(currentHeader[key])) ? currentHeader[key] : [currentHeader[key]];
     const expectedHeaderValue = (Array.isArray(val)) ? val : [val];
 
-    if (currentHeaderValue === expectedHeaderValue) {
-		return true;
-    }
-
-    if (!currentHeaderValue || !expectedHeaderValue) {
-		return false;
-	}
-
     if (currentHeaderValue.length !== expectedHeaderValue.length) {
 		return false;
     }

--- a/test/custom-header.spec.js
+++ b/test/custom-header.spec.js
@@ -1,0 +1,64 @@
+'use strict';
+const expect = require('chai').expect;
+
+module.exports = (fetchMock, theGlobal, Headers) => {
+
+    describe('fetch-mock', () => {
+
+        const dummyFetch = () => Promise.resolve(arguments);
+
+        before(() => {
+            theGlobal.fetch = dummyFetch;
+        })
+
+        describe('Interface', () => {
+
+            it('handles Headers class configuration correctly', () => {
+                fetchMock.mock({
+                    name: 'route1',
+                    headers: {
+                        test: 'yes'
+                    },
+                    matcher: 'http://it.at.here/',
+                    response: 'ok'
+                }).catch();
+                return Promise.all([
+                    fetch('http://it.at.here/', {headers: {test: 'yes'}}),
+                    fetch('http://it.at.here/', {headers: new Headers({test: 'yes'})}),
+                    fetch('http://it.at.here/')
+                ])
+                    .then(() => {
+                        expect(fetchMock.called()).to.be.true;
+                        expect(fetchMock.called('route1')).to.be.true;
+                        expect(fetchMock.calls('route1').length).to.equal(2);
+                        expect(fetchMock.calls().matched.length).to.equal(2);
+                        expect(fetchMock.calls().unmatched.length).to.equal(1);
+                    });
+            });
+
+            it('handles headers with multiple values correctly', () => {
+                fetchMock.mock({
+                    name: 'route1',
+                    headers: {
+                        test: ['foo', 'bar']
+                    },
+                    matcher: 'http://it.at.here/',
+                    response: 'ok'
+                }).catch();
+                return Promise.all([
+                    fetch('http://it.at.here/', {headers: {test: 'yes'}}),
+                    fetch('http://it.at.here/', {headers: {test: ['foo', 'bar']}}),
+                    fetch('http://it.at.here/')
+                ])
+                    .then(() => {
+                        expect(fetchMock.called()).to.be.true;
+                        expect(fetchMock.called('route1')).to.be.true;
+                        expect(fetchMock.calls('route1').length).to.equal(1);
+                        expect(fetchMock.calls().matched.length).to.equal(1);
+                        expect(fetchMock.calls().unmatched.length).to.equal(2);
+                    });
+            });
+        })
+
+    });
+}

--- a/test/custom-header.spec.js
+++ b/test/custom-header.spec.js
@@ -60,5 +60,9 @@ module.exports = (fetchMock, theGlobal, Headers) => {
             });
         })
 
+        afterEach(() => {
+            fetchMock.restore();
+        })
+
     });
 }

--- a/test/server.js
+++ b/test/server.js
@@ -15,6 +15,7 @@ const dummyFetch = function () {
 
 
 require('./spec')(fetchMock, global, require('node-fetch').Request, require('node-fetch').Response);
+//require('./custom-header.spec')(fetchMock, global, require('node-fetch').Headers);
 
 describe('support for Buffers', function () {
 	it('can respond with a buffer', function () {

--- a/test/server.js
+++ b/test/server.js
@@ -15,7 +15,7 @@ const dummyFetch = function () {
 
 
 require('./spec')(fetchMock, global, require('node-fetch').Request, require('node-fetch').Response);
-//require('./custom-header.spec')(fetchMock, global, require('node-fetch').Headers);
+require('./custom-header.spec')(fetchMock, global, require('node-fetch').Headers);
 
 describe('support for Buffers', function () {
 	it('can respond with a buffer', function () {

--- a/test/spec.js
+++ b/test/spec.js
@@ -109,10 +109,6 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 		});
 
 		describe('catch() and spy()', () => {
-			beforeEach(() => {
-				fetchMock.restore();
-			});
-
 			it('can catch all calls to fetch with good response by default', () => {
 				fetchMock.catch();
 				return fetch('http://place.com/')
@@ -163,11 +159,6 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 		})
 
 		describe('mock()', () => {
-
-			beforeEach(() => {
-				fetchMock.restore();
-			});
-
 			describe('parameters', () => {
 				beforeEach(() => {
 					sinon.stub(fetchMock, 'addRoute');
@@ -1088,7 +1079,6 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 						sendAsJson: true
 					});
 				}
-				fetchMock.restore();
 			});
 
 			describe('fetch utility class implementations', () => {
@@ -1382,7 +1372,6 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 				expect(() => {
 					fetchMock.mock('http://foo.com', { foo: 'bar' }, { method: 'GET' })
 				}).to.not.throw();
-				fetchMock.restore();
 			})
 
 			it('should expect valid statuses', () => {
@@ -1391,7 +1380,6 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 					.to.throw(`Invalid status not number passed on response object.
 To respond with a JSON object that has status as a property assign the object to body
 e.g. {"body": {"status: "registered"}}`);
-				fetchMock.restore();
 			})
 
 			it('should restore successfully after multiple mocks', () => {

--- a/test/spec.js
+++ b/test/spec.js
@@ -1442,5 +1442,9 @@ e.g. {"body": {"status: "registered"}}`);
 
 		})
 
+        afterEach(() => {
+            fetchMock.restore();
+        })
+
 	});
 }


### PR DESCRIPTION
Hi there,

I had some strange handling with `fetch-mock` and testing custom header definitions.
Therefore, I opened this PR by adding two test cases, that will fail (tested locally).

It would be great if you could check this PR and leave me a reply on it. (Please check the two comments for detailed information.)
_IMHO_ the `getHeaderMatcher` in [compile-route.js](https://github.com/wheresrhys/fetch-mock/blob/master/src/compile-route.js#L22) should / could be enhanced to handle the two cases.


Don't hesitate contacting me if you have any question on it.