### PR TITLE
Added includeContentLength to the configuration

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -121,7 +121,8 @@ Returns the options for the last matched call to fetch
 
 #### `configure(opts)`
 Set some global config options, which include
-* `sendAsJson` [default `true`] - by default fetchMock will convert objects to JSON before sending. This is overrideable fro each call but for some scenarios e.g. when dealing with a lot of array buffers, it can be useful to default to `false`
+* `sendAsJson` [default `true`] - by default fetchMock will convert objects to JSON before sending. This is overrideable from each call but for some scenarios e.g. when dealing with a lot of array buffers, it can be useful to default to `false`
+* `includeContentLength` [default `false`]: When set to true this will make fetchMock automatically add the `content-length` header. This is especially useful when combined with `sendAsJson` because then fetchMock does the conversion to JSON for you and knows the resulting length so you don’t have to compute this yourself by basically doing the same conversion to JSON.
 
 #### `setImplementations(opts)`
 When using non global fetch (e.g. a ponyfill) or an alternative Promise implementation, this will configure fetch-mock to use your chosen implementations. `opts` is an object with one or more of the following properties: `Headers`,`Request`,`Response`,`Promise`. Note that `setImplementations(require('fetch-ponyfill')())` will configure fetch-mock to use all of fetch-ponyfill's classes. 

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,6 +36,7 @@ Replaces `fetch()` with a stub which records its calls, grouped by route, and op
         * `headers`: Set the response headers. (`object`)
         * `throws`: If this property is present then a `Promise` rejected with the value of `throws` is returned
         * `sendAsJson`: This property determines whether or not the request body should be JSON.stringified before being sent (defaults to true).
+        * `includeContentLength`: Set this property to true to automatically add the `content-length` header (defaults to false).
     * `Function(url, opts)`: A function that is passed the url and opts `fetch()` is called with and that returns any of the responses listed above (or a `Promise` for any of them)
 * `options`: A configuration object with all/additional properties to define a route to mock
     * `name`: A unique string naming the route. Used to subsequently retrieve references to the calls, grouped by name. If not specified defaults to `matcher.toString()` *Note: If a non-unique name is provided no error will be thrown (because names are optional, so auto-generated ones may legitimately clash)*

--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -206,6 +206,12 @@ e.g. {"body": {"status: "registered"}}`);
 		body = JSON.stringify(body);
 	}
 
+	// add a Content-Length header if we need to
+	opts.includeContentLength = responseConfig.includeContentLength === undefined ? FetchMock.config.includeContentLength : responseConfig.includeContentLength;
+	if (opts.includeContentLength && typeof body === 'string' && !opts.headers.has('Content-Length')) {
+		opts.headers.set('Content-Length', body.length.toString());
+	}
+
 	// On the server we need to manually construct the readable stream for the
 	// Response object (on the client this is done automatically)
 	if (FetchMock.stream) {
@@ -330,6 +336,7 @@ FetchMock.prototype.done = function (name) {
 }
 
 FetchMock.config = {
+	includeContentLength: false,
 	sendAsJson: true
 }
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -1349,7 +1349,7 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 					});
 			});
 
-			it('should ignore case of explicit content-length header', done => {
+			it('should be case-insensitive when checking for explicit content-length header', done => {
 				fetchMock.mock('http://it.at.there/', {
 					body: {
 						hello: 'world'

--- a/test/spec.js
+++ b/test/spec.js
@@ -1148,6 +1148,60 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 				}
 			});
 
+			it('has includeContentLength off by default', done => {
+				fetchMock.mock('http://it.at.there/', {body: {hello: 'world'}});
+				fetch('http://it.at.there/')
+					.then(res => {
+						expect(res.headers.has('content-length')).to.be.false;
+						done();
+					});
+			});
+
+			it('can configure includeContentLength on', done => {
+				fetchMock.configure({
+					includeContentLength: true
+				});
+				fetchMock.mock('http://it.at.there/', {body: {hello: 'world'}});
+				fetch('http://it.at.there/')
+					.then(res => {
+						expect(res.headers.get('content-length')).to.equal('17');
+						fetchMock.configure({
+							includeContentLength: false
+						});
+						done();
+					});
+			});
+
+			it('includeContentLength can override the global setting to on', done => {
+				fetchMock.configure({
+					includeContentLength: false
+				});
+				fetchMock.mock('http://it.at.there/', {body: {hello: 'world'}, includeContentLength: true});
+				fetch('http://it.at.there/')
+					.then(res => {
+						expect(res.headers.get('content-length')).to.equal('17');
+						fetchMock.configure({
+							includeContentLength: false
+						});
+						done();
+					});
+			});
+
+			it('includeContentLength can override the global setting to off', done => {
+				fetchMock.configure({
+					includeContentLength: true
+				});
+				fetchMock.mock('http://it.at.there/', {body: {hello: 'world'}, includeContentLength: false});
+				fetch('http://it.at.there/')
+					.then(res => {
+						expect(res.headers.has('content-length')).to.be.false;
+						fetchMock.configure({
+							includeContentLength: false
+						});
+						done();
+					});
+			});
+
 			describe('fetch utility class implementations', () => {
 				const FetchMock = require('../src/fetch-mock');
 				const originalImplementations = {
@@ -1258,6 +1312,61 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 
 			});
 		})
+
+		describe('includeContentLength', () => {
+			it('should work on body of type object', done => {
+				fetchMock.mock('http://it.at.there/', {body: {hello: 'world'}, includeContentLength: true});
+				fetch('http://it.at.there/')
+					.then(res => {
+						expect(res.headers.get('content-length')).to.equal('17');
+						done();
+					});
+			});
+
+			it('should work on body of type string', done => {
+				fetchMock.mock('http://it.at.there/', {body: 'Fetch-Mock rocks', includeContentLength: true});
+				fetch('http://it.at.there/')
+					.then(res => {
+						expect(res.headers.get('content-length')).to.equal('16');
+						done();
+					});
+			});
+
+			it('should not overrule explicit mocked content-length header', done => {
+				fetchMock.mock('http://it.at.there/', {
+					body: {
+						hello: 'world'
+					}, 
+					headers: {
+						'Content-Length': '100',
+					},
+					includeContentLength: true
+				});
+				fetch('http://it.at.there/')
+					.then(res => {
+						expect(res.headers.get('content-length')).to.equal('100');
+						done();
+					});
+			});
+
+			it('should ignore case of explicit content-length header', done => {
+				fetchMock.mock('http://it.at.there/', {
+					body: {
+						hello: 'world'
+					}, 
+					headers: {
+						'CoNtEnT-LeNgTh': '100',
+					},
+					includeContentLength: true
+				});
+				fetch('http://it.at.there/')
+					.then(res => {
+						expect(res.headers.get('content-length')).to.equal('100');
+						done();
+					});
+			});
+
+		});
 
 		describe('sandbox', () => {
 			it('return function', () => {


### PR DESCRIPTION
I've added the `includeContentLength` option to both the global and the per route settings as you suggested. I've also added a couple of unit-tests and added a line to the documentation.

I hope this is what you had in mind.

P.S. One or two browser tests fail, but they also failed before I touched the code. This happens both on my local machine and on a Travis build.