### PR TITLE
Match urls with query params event if the params are not in the same order

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "glob-to-regexp": "^0.3.0",
     "node-fetch": "^1.3.3",
-    "path-to-regexp": "^1.7.0"
+    "path-to-regexp": "^1.7.0",
+    "query-string": "^5.0.1"
   },
   "devDependencies": {
     "babel": "^6.0.15",

--- a/test/spec.js
+++ b/test/spec.js
@@ -556,7 +556,17 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 						});
 				});
 
-				it('have helpers to retrieve paramaters pf last call', () => {
+                it('should match urls with same query string but in a different order', () => {
+                    fetchMock
+                        .mock('http://some.url/param?a=1&b=2', 200);
+
+                    return fetch('http://some.url/param?b=2&a=1')
+                        .then(function () {
+                            expect(fetchMock.called('http://some.url/param?a=1&b=2')).to.be.true;
+                        })
+                })
+
+                it('have helpers to retrieve paramaters pf last call', () => {
 					fetchMock.mock({
 						name: 'route',
 						matcher: '^http://it.at.there',


### PR DESCRIPTION
See https://github.com/wheresrhys/fetch-mock/issues/227

* For cases where the url is a valid one we'll do a less basic equality check by separating the query params and compare them separately

* Added basic test

* Add query-string package to parse the query strings.