### PR TITLE
Override Matcher Feature

### DIFF
--- a/src/compile-route.js
+++ b/src/compile-route.js
@@ -82,7 +82,12 @@ function normalizeRequest (url, options, Request) {
 	}
 }
 
-module.exports = function (route, Request, HeadersConstructor) {
+exports.buildMatcherName = function (route) {
+	const methodString = route.method ? route.method.toString() + ': ' : '';
+	return methodString + route.matcher.toString()
+}
+
+exports.compileRoute = function (route, Request, HeadersConstructor) {
 	route = Object.assign({}, route);
 
 	if (typeof route.response === 'undefined') {
@@ -94,7 +99,7 @@ module.exports = function (route, Request, HeadersConstructor) {
 	}
 
 	if (!route.name) {
-		route.name = route.matcher.toString();
+		route.name = exports.buildMatcherName(route);
 		route.__unnamed = true;
 	}
 

--- a/src/fetch-mock.js
+++ b/src/fetch-mock.js
@@ -1,8 +1,12 @@
 'use strict';
 
-const compileRoute = require('./compile-route');
+const compileRouteModule = require('./compile-route');
+const compileRoute = compileRouteModule.compileRoute;
+const buildMatcherName = compileRouteModule.buildMatcherName;
 
 const FetchMock = {};
+
+const NOT_FOUND = -1;
 
 FetchMock.config = {
 	includeContentLength: false,
@@ -160,6 +164,16 @@ FetchMock.addRoute = function (route) {
 	if (!route) {
 		throw new Error('.mock() must be passed configuration for a route')
 	}
+
+  	const foundIndex = this.routes.findIndex(registeredRoute => {
+    		return buildMatcherName(route) === registeredRoute.name
+  	});
+
+  	// If duplicate matcher found, delete the old one. This provides the ability to
+  	// override the response for a specific matcher
+  	if (foundIndex !== NOT_FOUND) {
+    		this.routes.splice(foundIndex, 1);
+  	}
 
 	// Allows selective application of some of the preregistered routes
 	this.routes.push(compileRoute(route, this.config.Request, this.config.Headers));

--- a/test/spec.js
+++ b/test/spec.js
@@ -1075,20 +1075,39 @@ module.exports = (fetchMock, theGlobal, Request, Response) => {
 						})
 				});
 
-				it('falls back to second route if first route already matched enough times', function () {
+				it('overrides an existing string matcher', function () {
 					fetchMock
-						.mock('http://it.at.there1/', 404, {times: 1})
+						.mock('http://it.at.there1/', 404)
 						.mock('http://it.at.there1/', 200);
 
 					return fetch('http://it.at.there1/')
 						.then(res => {
-							expect(res.status).to.equal(404);
-						})
-						.then(() => fetch('http://it.at.there1/'))
-						.then(res => {
 							expect(res.status).to.equal(200);
 						})
 				});
+
+        			it('overrides an existing regex matcher', function () {
+          				fetchMock
+            					.mock(/person/, 404)
+            					.mock(/person/, 200)
+            					.mock(/person/, 201);
+
+          				return fetch('person')
+            					.then(res => {
+              						expect(res.status).to.equal(201);
+            					})
+        			});
+
+        			it('overrides an existing function matcher', function () {
+          				fetchMock
+            					.mock(url => /person/.test(url) , 404)
+            					.mock(url => /person/.test(url) , 200);
+
+          				return fetch('person')
+            					.then(res => {
+              						expect(res.status).to.equal(200);
+            					})
+        				});
 
 				it('reset() resets count', () => {
 					fetchMock


### PR DESCRIPTION
See #234 

Why:
* To provide the ability to override the response for a given matcher

How:
* Added logic to check for duplicate matchers when adding them. If a
  duplicate is found, then delete the old one and add the new one.
* Added unit tests to verify overriding behavior for string, regex,
  and function matchers.
* Removed the test for falling-back to previous matcher because it
  directly conflicts with the overriding feature.
* Modified the route name creation to include the method so that
  GET and POST mocks don't register as the same matcher
* Refactored compile-route.js to provide two named exports