### PR TITLE
Add support for matching referrer, referrerPolicy and credentials options

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,7 @@
 'use strict';
 
-module.exports = function(karma) {
-	var configuration = {
+module.exports = function (karma) {
+	const configuration = {
 
 		frameworks: [ 'mocha', 'chai', 'browserify'],
 		files: [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function (karma) {
 			debug: true,
 			transform: [
 				['babelify', {
-					'presets': ['env'],
+					'presets': ['es2017'],
 					'plugins': ['transform-object-assign']
 				}]
 			]

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function (karma) {
 			debug: true,
 			transform: [
 				['babelify', {
-					'presets': ['es2017'],
+					'presets': ['env'],
 					'plugins': ['transform-object-assign']
 				}]
 			]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "make lint test",
     "browserify": "browserify -s fetchMock es5/client.js > es5/client-bundle.js",
-    "prepublish": "babel src --out-dir es5 --plugins transform-object-assign --presets babel-preset-env && npm run browserify"
+    "prepublish": "babel src --out-dir es5 --plugins transform-object-assign --presets es2017 && npm run browserify"
   },
   "repository": {
     "type": "git",
@@ -33,9 +33,10 @@
     "path-to-regexp": "^1.7.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
+    "babel": "^6.0.15",
+    "babel-cli": "^6.1.2",
     "babel-plugin-transform-object-assign": "^6.8.0",
-    "babel-preset-env": "^1.6.1",
+    "babel-preset-es2017": "^6.1.2",
     "babelify": "^7.3.0",
     "bluebird": "^3.4.6",
     "browserify": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "make lint test",
     "browserify": "browserify -s fetchMock es5/client.js > es5/client-bundle.js",
-    "prepublish": "babel src --out-dir es5 --plugins transform-object-assign --presets es2017 && npm run browserify"
+    "prepublish": "babel src --out-dir es5 --plugins transform-object-assign --presets babel-preset-env && npm run browserify"
   },
   "repository": {
     "type": "git",
@@ -33,10 +33,9 @@
     "path-to-regexp": "^1.7.0"
   },
   "devDependencies": {
-    "babel": "^6.0.15",
-    "babel-cli": "^6.1.2",
+    "babel-cli": "^6.26.0",
     "babel-plugin-transform-object-assign": "^6.8.0",
-    "babel-preset-es2017": "^6.1.2",
+    "babel-preset-env": "^1.6.1",
     "babelify": "^7.3.0",
     "bluebird": "^3.4.6",
     "browserify": "^13.1.0",

--- a/src/lib/compile-route.js
+++ b/src/lib/compile-route.js
@@ -175,6 +175,14 @@ const getReferrerMatcher = route => {
 	}
 }
 
+const getCredentialsMatcher = route => {
+	return (req, [, options]) => {
+		const routeCreds = route && route.credentials && route.credentials.toLowerCase();
+		const optionsCreds = options && options.credentials && options.credentials.toLowerCase();
+		return routeCreds === optionsCreds;
+	}
+}
+
 const generateMatcher = (route, config) => {
 	const matchers = [
 		getQueryStringMatcher(route),
@@ -182,7 +190,8 @@ const generateMatcher = (route, config) => {
 		getHeaderMatcher(route, config.Headers),
 		getUrlMatcher(route),
 		getFunctionMatcher(route),
-		getReferrerMatcher(route)
+		getReferrerMatcher(route),
+		getCredentialsMatcher(route)
 	];
 
 	return (url, options) => {

--- a/src/lib/compile-route.js
+++ b/src/lib/compile-route.js
@@ -167,13 +167,22 @@ const getFunctionMatcher = route => {
 	}
 }
 
+const getReferrerMatcher = route => {
+	return (req, [, options]) => {
+		const routeReferrer = route && route.referrer && route.referrer.toLowerCase();
+		const optionsReferrer = options && options.referrer && options.referrer.toLowerCase();
+		return routeReferrer === optionsReferrer;
+	}
+}
+
 const generateMatcher = (route, config) => {
 	const matchers = [
 		getQueryStringMatcher(route),
 		getMethodMatcher(route),
 		getHeaderMatcher(route, config.Headers),
 		getUrlMatcher(route),
-		getFunctionMatcher(route)
+		getFunctionMatcher(route),
+		getReferrerMatcher(route)
 	];
 
 	return (url, options) => {

--- a/src/lib/compile-route.js
+++ b/src/lib/compile-route.js
@@ -170,6 +170,9 @@ const getFunctionMatcher = route => {
 const getStringOptionsMatcher = route => {
 	return (req, [, options]) => {
 		return ['referrer', 'referrerPolicy', 'credentials'].map(option => {
+			if (!route[option]) {
+				return true;
+			}
 			const matcherOption = route && route[option] && route[option].toLowerCase();
 			const requestOption = options && options[option] && options[option].toLowerCase();
 			return matcherOption === requestOption;

--- a/src/lib/compile-route.js
+++ b/src/lib/compile-route.js
@@ -167,27 +167,13 @@ const getFunctionMatcher = route => {
 	}
 }
 
-const getReferrerMatcher = route => {
+const getStringOptionsMatcher = route => {
 	return (req, [, options]) => {
-		const routeReferrer = route && route.referrer && route.referrer.toLowerCase();
-		const optionsReferrer = options && options.referrer && options.referrer.toLowerCase();
-		return routeReferrer === optionsReferrer;
-	}
-}
-
-const getReferrerPolicyMatcher = route => {
-	return (req, [, options]) => {
-		const routeReferrerPolicy = route && route.referrerPolicy && route.referrerPolicy.toLowerCase();
-		const optionsReferrerPolicy = options && options.referrerPolicy && options.referrerPolicy.toLowerCase();
-		return routeReferrerPolicy === optionsReferrerPolicy;
-	}
-}
-
-const getCredentialsMatcher = route => {
-	return (req, [, options]) => {
-		const routeCreds = route && route.credentials && route.credentials.toLowerCase();
-		const optionsCreds = options && options.credentials && options.credentials.toLowerCase();
-		return routeCreds === optionsCreds;
+		return ['referrer', 'referrerPolicy', 'credentials'].map(option => {
+			const matcherOption = route && route[option] && route[option].toLowerCase();
+			const requestOption = options && options[option] && options[option].toLowerCase();
+			return matcherOption === requestOption;
+		}).every(match => match);
 	}
 }
 
@@ -198,9 +184,7 @@ const generateMatcher = (route, config) => {
 		getHeaderMatcher(route, config.Headers),
 		getUrlMatcher(route),
 		getFunctionMatcher(route),
-		getReferrerMatcher(route),
-		getReferrerPolicyMatcher(route),
-		getCredentialsMatcher(route)
+		getStringOptionsMatcher(route)
 	];
 
 	return (url, options) => {

--- a/src/lib/compile-route.js
+++ b/src/lib/compile-route.js
@@ -175,6 +175,14 @@ const getReferrerMatcher = route => {
 	}
 }
 
+const getReferrerPolicyMatcher = route => {
+	return (req, [, options]) => {
+		const routeReferrerPolicy = route && route.referrerPolicy && route.referrerPolicy.toLowerCase();
+		const optionsReferrerPolicy = options && options.referrerPolicy && options.referrerPolicy.toLowerCase();
+		return routeReferrerPolicy === optionsReferrerPolicy;
+	}
+}
+
 const getCredentialsMatcher = route => {
 	return (req, [, options]) => {
 		const routeCreds = route && route.credentials && route.credentials.toLowerCase();
@@ -191,6 +199,7 @@ const generateMatcher = (route, config) => {
 		getUrlMatcher(route),
 		getFunctionMatcher(route),
 		getReferrerMatcher(route),
+		getReferrerPolicyMatcher(route),
 		getCredentialsMatcher(route)
 	];
 

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -402,6 +402,65 @@ module.exports = (fetchMock) => {
 					});
 				})
 			});
+
+			describe('referrer', () => {
+				it('not match when referrer not present', async () => {
+					fm
+						.mock('http://it.at.there/', 200, {
+							referrer: 'http://referrer.example.com'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/')
+					expect(fm.calls(true).length).to.equal(0);
+				});
+
+				it('not match when referrer does\'t match', async () => {
+					fm
+						.mock('http://it.at.there/', 200, {
+							referrer: 'http://referrer.example.com'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/', { referrer: 'http://other.referrer.example.com' })
+					expect(fm.calls(true).length).to.equal(0);
+				});
+
+				it('match referrers', async () => {
+					fm
+						.mock('http://it.at.there/', 200, {
+							referrer: 'http://referrer.example.com'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/', { referrer: 'http://referrer.example.com' })
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
+				it('be case insensitive', async () => {
+					fm
+						.mock('http://it.at.there/', 200, {
+							referrer: 'http://referrer.example.com'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/', { referrer: 'HTTP://REFERRER.EXAMPLE.COM' })
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
+				it('can be used alongside function matchers', async () => {
+					fm
+						.mock(url => /person/.test(url), 200, {
+							referrer: 'http://referrer.example.com'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://domain.com/person');
+					expect(fm.calls(true).length).to.equal(0);
+					await fm.fetchHandler('http://domain.com/person', { referrer: 'http://referrer.example.com' });
+					expect(fm.calls(true).length).to.equal(1);
+				})
+			});
 		});
 
 		describe('multiple routes', () => {

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -463,7 +463,7 @@ module.exports = (fetchMock) => {
 			});
 
 			describe('referrerPolicy', () => {
-				it('not match when credentials not present', async () => {
+				it('not match when referrerPolicy not present', async () => {
 					fm
 						.mock('http://it.at.there/', 200, {
 							referrerPolicy: 'origin'

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -426,6 +426,15 @@ module.exports = (fetchMock) => {
 					expect(fm.calls(true).length).to.equal(0);
 				});
 
+				it('match when referrer option isn\'t passed as a matcher', async () => {
+					fm
+						.mock('http://it.at.there/', 200)
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/', { referrer: 'http://other.referrer.example.com' })
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
 				it('match referrers', async () => {
 					fm
 						.mock('http://it.at.there/', 200, {
@@ -496,6 +505,15 @@ module.exports = (fetchMock) => {
 					expect(fm.calls(true).length).to.equal(1);
 				});
 
+				it('match when referrerPolicy option isn\'t passed as a matcher', async () => {
+					fm
+						.mock('http://it.at.there/', 200)
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/', { referrerPolicy: 'no-referrer' })
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
 				it('be case insensitive', async () => {
 					fm
 						.mock('http://it.at.there/', 200, {
@@ -549,6 +567,15 @@ module.exports = (fetchMock) => {
 						.mock('http://it.at.there/', 200, {
 							credentials: 'same-origin'
 						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/', { credentials: 'same-origin' })
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
+				it('match when credentials option isn\'t passed as a matcher', async () => {
+					fm
+						.mock('http://it.at.there/', 200)
 						.catch();
 
 					await fm.fetchHandler('http://it.at.there/', { credentials: 'same-origin' })

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -461,6 +461,65 @@ module.exports = (fetchMock) => {
 					expect(fm.calls(true).length).to.equal(1);
 				})
 			});
+
+			describe('credentials', () => {
+				it('not match when credentials not present', async () => {
+					fm
+						.mock('http://it.at.there/', 200, {
+							credentials: 'same-origin'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/')
+					expect(fm.calls(true).length).to.equal(0);
+				});
+
+				it('not match when credentials does\'t match', async () => {
+					fm
+						.mock('http://it.at.there/', 200, {
+							credentials: 'same-origin'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/', { credentials: 'omit' })
+					expect(fm.calls(true).length).to.equal(0);
+				});
+
+				it('match credentialss', async () => {
+					fm
+						.mock('http://it.at.there/', 200, {
+							credentials: 'same-origin'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/', { credentials: 'same-origin' })
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
+				it('be case insensitive', async () => {
+					fm
+						.mock('http://it.at.there/', 200, {
+							credentials: 'same-origin'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/', { credentials: 'SAME-ORIGIN' })
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
+				it('can be used alongside function matchers', async () => {
+					fm
+						.mock(url => /person/.test(url), 200, {
+							credentials: 'same-origin'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://domain.com/person');
+					expect(fm.calls(true).length).to.equal(0);
+					await fm.fetchHandler('http://domain.com/person', { credentials: 'same-origin' });
+					expect(fm.calls(true).length).to.equal(1);
+				})
+			});
 		});
 
 		describe('multiple routes', () => {

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -462,6 +462,65 @@ module.exports = (fetchMock) => {
 				})
 			});
 
+			describe('referrerPolicy', () => {
+				it('not match when credentials not present', async () => {
+					fm
+						.mock('http://it.at.there/', 200, {
+							referrerPolicy: 'origin'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/')
+					expect(fm.calls(true).length).to.equal(0);
+				});
+
+				it('not match when referrer-policy does\'t match', async () => {
+					fm
+						.mock('http://it.at.there/', 200, {
+							referrerPolicy: 'origin'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/', { referrerPolicy: 'no-referrer' })
+					expect(fm.calls(true).length).to.equal(0);
+				});
+
+				it('match referrer-policys', async () => {
+					fm
+						.mock('http://it.at.there/', 200, {
+							referrerPolicy: 'origin'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/', { referrerPolicy: 'origin' })
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
+				it('be case insensitive', async () => {
+					fm
+						.mock('http://it.at.there/', 200, {
+							referrerPolicy: 'origin'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://it.at.there/', { referrerPolicy: 'ORIGIN' })
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
+				it('can be used alongside function matchers', async () => {
+					fm
+						.mock(url => /person/.test(url), 200, {
+							referrerPolicy: 'origin'
+						})
+						.catch();
+
+					await fm.fetchHandler('http://domain.com/person');
+					expect(fm.calls(true).length).to.equal(0);
+					await fm.fetchHandler('http://domain.com/person', { referrerPolicy: 'origin' });
+					expect(fm.calls(true).length).to.equal(1);
+				})
+			});
+
 			describe('credentials', () => {
 				it('not match when credentials not present', async () => {
 					fm


### PR DESCRIPTION
Handles some of #239 (Also #238)
  

Just to double check the case here, am I right in thinking this should pass?
```js
it('match when credentials option isn\'t passed as a matcher', async () => {
	fm
		.mock('http://it.at.there/', 200)
		.catch();

	await fm.fetchHandler('http://it.at.there/', { credentials: 'same-origin' })
	expect(fm.calls(true).length).to.equal(1);
});
```

Where the mock isn't passed an option to match on `credentials` but it is given to `fetch` as an option.