### PR TITLE
Move node-fetch to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "homepage": "http://www.wheresrhys.co.uk/fetch-mock",
   "dependencies": {
     "glob-to-regexp": "^0.3.0",
+    "node-fetch": "^2.0.0",
     "path-to-regexp": "^2.1.0"
   },
   "devDependencies": {
@@ -68,7 +69,6 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "^2.0.9",
     "mocha": "^4.0.1",
-    "node-fetch": "^2.0.0",
     "sinon": "^4.1.3",
     "sinon-chai": "^2.14.0",
     "webpack": "^3.10.0"


### PR DESCRIPTION
`node-fetch` should be in the `dependencies`. If not, the module will return:

```sh
  ● Test suite failed to run

    Cannot find module 'node-fetch' from 'server.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:169:17)
      at Object.<anonymous> (node_modules/fetch-mock/src/server.js:2:15)
```

Workaround is to include it in the parent project, which is not optimal imho.