### PR TITLE
Adding core-js to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "node-fetch": "^2.0.0",
     "sinon": "^4.1.3",
     "sinon-chai": "^2.14.0",
-    "webpack": "^3.10.0"
+    "webpack": "^3.10.0",
+    "core-js": "^2.5.4"
   }
 }


### PR DESCRIPTION
There are the problem with npm installation of fetch-mock:

Module not found: Can't resolve 'core-js/modules/es7.string.pad-end' in '/home/myProject/node_modules/fetch-mock/es5

Works only with yarn installation.

According to https://github.com/babel/babel-preset-env/issues/304