### PR TITLE
Move node-fetch to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6594,11 +6594,11 @@
       "integrity": "sha512-KPKb+wvETBiwb4eTwtR/OsA2+iijXP+VnlSFYJo3EHjm2yjek1NWxHOUQat3i7xNLm1Bm18UA5j5Wor0yO2GtA==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
-        "lolex": "^2.2.0",
-        "path-to-regexp": "^1.7.0",
-        "text-encoding": "^0.6.4"
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.3.2",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
       },
       "dependencies": {
         "isarray": {
@@ -6619,10 +6619,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.1.tgz",
-      "integrity": "sha1-NpynC4L1DIZJYQSmx3bSdPTkotQ=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://nexus.intern.sparebank1.no/nexus/content/groups/npmgroup/node-fetch/-/node-fetch-2.0.0.tgz",
+      "integrity": "sha1-mCu6Q+zU8pIqKcwYamu7C7c/y6Y="
     },
     "node-libs-browser": {
       "version": "2.1.0",
@@ -8025,12 +8024,12 @@
       "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.1.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.2.0",
-        "nise": "^1.2.0",
-        "supports-color": "^5.1.0",
+        "@sinonjs/formatio": "2.0.0",
+        "diff": "3.5.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.2",
+        "nise": "1.3.2",
+        "supports-color": "5.3.0",
         "type-detect": "4.0.8"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "homepage": "http://www.wheresrhys.co.uk/fetch-mock",
   "dependencies": {
     "glob-to-regexp": "^0.4.0",
+    "node-fetch": "^2.0.0",
     "path-to-regexp": "^2.1.0"
   },
   "devDependencies": {
@@ -69,7 +70,6 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "^2.0.9",
     "mocha": "^5.0.0",
-    "node-fetch": "^2.0.0",
     "sinon": "^4.5.0",
     "sinon-chai": "^2.14.0",
     "webpack": "^3.10.0"


### PR DESCRIPTION
Hi! Thanks a bunch for the work you've put into `fetch-mock`!

I ran into an issue related to #261 where `fetch-mock` would throw an error due to missing `node-fetch` since I didn't have `node-fetch` in my own `package.json`.

This commit moves `node-fetch` from `devDependencies` to `dependencies` so we are sure consumers of `fetch-mock` gets the required version installed.

Naturally a workaround is to just declare `node-fetch` as a direct dependency in my project, but it would be nice to avoid since I don't use it directly.