### PR TITLE
Add failing test when relative URLs are requested

### DIFF
--- a/src/lib/compile-route.js
+++ b/src/lib/compile-route.js
@@ -1,12 +1,12 @@
 const glob = require('glob-to-regexp')
 const express = require('path-to-regexp');
-const URL = require('url');
+const nodeURL = require('url');
 const querystring = require('querystring');
 
 function normalizeRequest (url, options, Request) {
 	if (Request.prototype.isPrototypeOf(url)) {
 		return {
-			url: url.url,
+			url: normalizeURL(url.url),
 			method: url.method,
 			headers: (() => {
 				const headers = {};
@@ -16,10 +16,22 @@ function normalizeRequest (url, options, Request) {
 		};
 	} else {
 		return {
-			url: url,
+			url: normalizeURL(url),
 			method: options && options.method || 'GET',
 			headers: options && options.headers
 		};
+	}
+}
+
+function normalizeURL (url) {
+	var r = new RegExp('^(?:[a-z]+:)?//', 'i'); // https://stackoverflow.com/a/19709846/308237
+	const absolute = r.test(url);
+	if (absolute) {
+		const u = new URL(url);
+		return u.href;
+	} else {
+		const u = new URL(url, 'http://dummy');
+		return u.pathname;
 	}
 }
 
@@ -95,7 +107,7 @@ const getQueryStringMatcher = route => {
 	}
 	const keys = Object.keys(route.query);
 	return ({ url }) => {
-		const query = querystring.parse(URL.parse(url).query);
+		const query = querystring.parse(nodeURL.parse(url).query);
 		return keys.every(key => query[key] === route.query[key]);
 	}
 }

--- a/test/specs/custom-implementations.test.js
+++ b/test/specs/custom-implementations.test.js
@@ -22,7 +22,7 @@ module.exports = (fetchMock) => {
 			it('can be configured to use alternate Promise implementations', async () => {
 				fm.config.Promise = BluebirdPromise
 				fm
-					.mock('http://example.com', 200)
+					.mock('http://example.com/', 200)
 				const fetchCall = fetch('http://example.com');
 				expect(fetchCall).to.be.instanceof(BluebirdPromise);
 				await fetchCall
@@ -43,7 +43,7 @@ module.exports = (fetchMock) => {
 
 			it('can use custom promises but return native promise', async () => {
 				fm
-					.mock('http://example.com', BluebirdPromise.resolve(200));
+					.mock('http://example.com/', BluebirdPromise.resolve(200));
 
 				const responsePromise = fm.fetchHandler('http://example.com');
 				expect(responsePromise).to.be.instanceof(NativePromise);

--- a/test/specs/inspecting.test.js
+++ b/test/specs/inspecting.test.js
@@ -118,8 +118,8 @@ module.exports = (fetchMock) => {
 		describe('call order', () => {
 			it('retrieves calls in correct order', () => {
 				fm
-					.mock('http://it.at.here', 200)
-					.mock('http://it.at.there', 200)
+					.mock('http://it.at.here/', 200)
+					.mock('http://it.at.there/', 200)
 					.catch()
 
 				fm.fetchHandler('http://it.at.here');
@@ -139,7 +139,7 @@ module.exports = (fetchMock) => {
 						name: 'my-route'
 					});
 
-				await fm.fetchHandler('http://it.at.here/');
+				await fm.fetchHandler('http://it.at.here');
 
 				expect(fm.called('my-route')).to.be.true;
 			});
@@ -240,8 +240,8 @@ module.exports = (fetchMock) => {
 
 			it('flush resolves if all fetches have resolved', async () => {
 				fm
-					.mock('http://one.com', 200)
-					.mock('http://two.com', 200)
+					.mock('http://one.com/', 200)
+					.mock('http://two.com/', 200)
 				// no expectation, but if it doesn't work then the promises will hang
 				// or reject and the test will timeout
 				await fm.flush()
@@ -252,7 +252,7 @@ module.exports = (fetchMock) => {
 			})
 
 			it('should resolve after fetches', async () => {
-				fm.mock('http://example', 'working!')
+				fm.mock('http://example/', 'working!')
 				let data;
 				fetch('http://example')
 					.then(() => data = 'done');
@@ -262,8 +262,8 @@ module.exports = (fetchMock) => {
 
 			it('flush waits for unresolved promises', async () => {
 				fm
-					.mock('http://one.com', 200)
-					.mock('http://two.com', () => new Promise(res => setTimeout(() => res(200), 50)))
+					.mock('http://one.com/', 200)
+					.mock('http://two.com/', () => new Promise(res => setTimeout(() => res(200), 50)))
 
 				const orderedResults = []
 				fetch('http://one.com')
@@ -278,7 +278,7 @@ module.exports = (fetchMock) => {
 
 			it('flush resolves on expected error', async () => {
 				fm
-					.mock('http://one.com', {throws: 'Problem in space'})
+					.mock('http://one.com/', {throws: 'Problem in space'})
 				await fm.flush();
 			});
 		});

--- a/test/specs/options.test.js
+++ b/test/specs/options.test.js
@@ -15,7 +15,7 @@ module.exports = (fetchMock, theGlobal, fetch) => {
 
 			it('not error when configured globally', async () => {
 				fm.config.fallbackToNetwork = true;
-				fm.mock('http://it.at.where', 200);
+				fm.mock('http://it.at.where/', 200);
 				expect(() => fm.fetchHandler('http://it.at.there/')).not.to.throw();
 			});
 
@@ -23,7 +23,7 @@ module.exports = (fetchMock, theGlobal, fetch) => {
 				fm.realFetch = fetch;
 				fm.config.fallbackToNetwork = true;
 
-				fm.mock('http://it.at.where', 204);
+				fm.mock('http://it.at.where/', 204);
 				const res = await fm.fetchHandler('http://localhost:9876/dummy-file.txt')
 				expect(res.status).to.equal(200);
 			});
@@ -45,7 +45,7 @@ module.exports = (fetchMock, theGlobal, fetch) => {
 				const sbx = fm.sandbox();
 				sbx.config.fetch = fetch;
 				sbx.config.fallbackToNetwork = true;
-				sbx.mock('http://it.at.where', 204);
+				sbx.mock('http://it.at.where/', 204);
 				const res = await sbx('http://localhost:9876/dummy-file.txt')
 				expect(res.status).to.equal(200);
 			});

--- a/test/specs/responses.test.js
+++ b/test/specs/responses.test.js
@@ -21,7 +21,7 @@ module.exports = (fetchMock) => {
 			});
 
 			it('should error on invalid statuses', async () => {
-				fm.mock('http://foo.com', { status: 'not number' })
+				fm.mock('http://foo.com/', { status: 'not number' })
 				try {
 					await fm.fetchHandler('http://foo.com')
 					expect(true).to.be.false;

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -40,7 +40,7 @@ module.exports = (fetchMock) => {
 
 			it('match end: keyword', async () => {
 				fm
-					.mock('end:there', 200)
+					.mock('end:there/', 200)
 					.catch();
 
 				await fm.fetchHandler('http://it.at.there');
@@ -286,7 +286,7 @@ module.exports = (fetchMock) => {
 			describe('query strings', () => {
 				it('can match a query string', async () => {
 					fm
-						.mock('http://it.at.there', 200, {query: {a: 'b'}})
+						.mock('http://it.at.there/', 200, {query: {a: 'b'}})
 						.catch();
 
 					await fm.fetchHandler('http://it.at.there');
@@ -297,7 +297,7 @@ module.exports = (fetchMock) => {
 
 				it('can match multiple query strings', async () => {
 					fm
-						.mock('http://it.at.there', 200, {query: {a: 'b', c: 'd'}})
+						.mock('http://it.at.there/', 200, {query: {a: 'b', c: 'd'}})
 						.catch();
 
 					await fm.fetchHandler('http://it.at.there');
@@ -312,7 +312,7 @@ module.exports = (fetchMock) => {
 
 				it('can be used alongside existing query strings', async () => {
 					fm
-						.mock('http://it.at.there?c=d', 200, {query: {a: 'b'}})
+						.mock('http://it.at.there/?c=d', 200, {query: {a: 'b'}})
 						.catch();
 
 					await fm.fetchHandler('http://it.at.there?c=d');
@@ -531,6 +531,17 @@ module.exports = (fetchMock) => {
 
 				await fm.fetchHandler('/it.at.there/')
 				expect(fm.calls(true).length).to.equal(1);
+			});
+
+			it('match relative urls with dots', async () => {
+				fm
+					.mock('/it.at/there/', 200)
+					.catch();
+
+				await fm.fetchHandler('/it.at/not/../there/')
+				expect(fm.calls(true).length).to.equal(1);
+				await fm.fetchHandler('./it.at/there/')
+				expect(fm.calls(true).length).to.equal(2);
 			});
 
 			it('match when called with Request', async () => {

--- a/test/specs/sandbox.test.js
+++ b/test/specs/sandbox.test.js
@@ -32,7 +32,7 @@ module.exports = (fetchMock, theGlobal) => {
 		it('delegate to its own fetch handler', async () => {
 			const sbx = fetchMock
 				.sandbox()
-				.mock('http://domain.url', 200);
+				.mock('http://domain.url/', 200);
 
 			sinon.stub(sbx, 'fetchHandler');
 
@@ -43,7 +43,7 @@ module.exports = (fetchMock, theGlobal) => {
 		it('don\'t interfere with global fetch', () => {
 			const sbx = fetchMock
 				.sandbox()
-				.mock('http://domain.url', 200)
+				.mock('http://domain.url/', 200)
 
 			expect(theGlobal.fetch).to.equal(originalFetch);
 			expect(theGlobal.fetch).not.to.equal(sbx);
@@ -52,11 +52,11 @@ module.exports = (fetchMock, theGlobal) => {
 		it('don\'t interfere with global fetch-mock', async () => {
 			const sbx = fetchMock
 				.sandbox()
-				.mock('http://domain.url', 200)
+				.mock('http://domain.url/', 200)
 				.catch(302)
 
 			fetchMock
-				.mock('http://domain2.url', 200)
+				.mock('http://domain2.url/', 200)
 				.catch(301)
 
 			expect(theGlobal.fetch).to.equal(fetchMock.fetchHandler);
@@ -82,12 +82,12 @@ module.exports = (fetchMock, theGlobal) => {
 		it('don\'t interfere with other sandboxes', async () => {
 			const sbx = fetchMock
 				.sandbox()
-				.mock('http://domain.url', 200)
+				.mock('http://domain.url/', 200)
 				.catch(301)
 
 			const sbx2 = fetchMock
 				.sandbox()
-				.mock('http://domain2.url', 200)
+				.mock('http://domain2.url/', 200)
 				.catch(302)
 
 			expect(sbx2).not.to.equal(sbx);


### PR DESCRIPTION
I've recently run into an issue where I'm unable to mock certain URLs which work fine in a web browser, as fetch-mock doesn't seem to support requests to relative URLs.

This PR is a failing test case which demonstrates the issue I am coming across.  Hopefully this explains the issue.