### PR TITLE
Add test for matching 'end:' with Request object

### DIFF
--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -50,6 +50,18 @@ module.exports = (fetchMock) => {
 				expect(fm.calls(true).length).to.equal(1);
 			});
 
+			it('match end: keyword with Request', async () => {
+				fm
+					.mock('end:there', 200)
+					.catch();
+
+				await fm.fetchHandler(new fm.config.Request('http://it.at.there', {method: 'GET'}));
+				expect(fm.calls(true).length).to.equal(1);
+				await fm.fetchHandler(new fm.config.Request('http://it.at.thereabouts', {method: 'GET'}));
+				await fm.fetchHandler(new fm.config.Request('http://it.at.here', {method: 'GET'}));
+				expect(fm.calls(true).length).to.equal(1);
+			});
+
 			it('match glob: keyword', async () => {
 				fm
 					.mock('glob:/its/*/*', 200)


### PR DESCRIPTION
This test exposes an issue with the `end:` matcher where it doesn't always work if the `fetch()` call has been passed a `Request` object instead of a string.

The problem is that the URL coming from the `Request` object is normalised, which results in it getting a slash appended to it.  This extra slash causes the string matcher (compile-route.js:31) to compare `here/` against `there` which is false, resulting in the `end:` matcher failing.

The same test but using strings instead of `Request` objects passes (as shown by the test directly before the new one in this PR, which I have copied to make the new test.)