### PR TITLE
Move prettier to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3310,12 +3310,14 @@
     "eslint-config-origami-component": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-origami-component/-/eslint-config-origami-component-1.0.0.tgz",
-      "integrity": "sha1-xqHXWLIns51QZ5b41ENFZTpwXkY="
+      "integrity": "sha1-xqHXWLIns51QZ5b41ENFZTpwXkY=",
+      "dev": true
     },
     "eslint-config-prettier": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz",
       "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
+      "dev": true,
       "requires": {
         "get-stdin": "^5.0.1"
       }
@@ -3324,6 +3326,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.1.tgz",
       "integrity": "sha512-wNZ2z0oVCWnf+3BSI7roS+z4gGu2AwcPKUek+SlLZMZg+X0KbZLsB2knul7fd0K3iuIp402HIYzm4f2+OyfXxA==",
+      "dev": true,
       "requires": {
         "fast-diff": "^1.1.1",
         "jest-docblock": "^21.0.0"
@@ -3567,7 +3570,8 @@
     "fast-diff": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
     },
     "fast-glob": {
       "version": "2.2.1",
@@ -4752,7 +4756,8 @@
     "get-stdin": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+      "dev": true
     },
     "get-stream": {
       "version": "3.0.0",
@@ -5917,7 +5922,8 @@
     "jest-docblock": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw=="
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -10761,7 +10767,8 @@
     "prettier": {
       "version": "1.13.7",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
-      "integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w=="
+      "integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -48,12 +48,8 @@
   "homepage": "http://www.wheresrhys.co.uk/fetch-mock",
   "dependencies": {
     "babel-polyfill": "^6.26.0",
-    "eslint-config-origami-component": "^1.0.0",
-    "eslint-config-prettier": "^2.9.0",
-    "eslint-plugin-prettier": "^2.6.1",
     "glob-to-regexp": "^0.4.0",
-    "path-to-regexp": "^2.2.1",
-    "prettier": "^1.13.7"
+    "path-to-regexp": "^2.2.1"
   },
   "engines": {
     "node": ">=4.0.0"
@@ -67,6 +63,9 @@
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
     "eslint": "^4.14.0",
+    "eslint-config-origami-component": "^1.0.0",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-prettier": "^2.6.1",
     "karma": "^2.0.2",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
@@ -76,6 +75,7 @@
     "mocha": "^5.1.1",
     "node-fetch": "^2.0.0",
     "nyc": "^11.7.3",
+    "prettier": "^1.13.7",
     "sinon": "^4.5.0",
     "sinon-chai": "^2.14.0",
     "webpack": "^4.0.0",


### PR DESCRIPTION
So users of `fetch-mock` don't install it. Thanks!