### PR TITLE
Added body to the normalized request

### DIFF
--- a/src/lib/compile-route.js
+++ b/src/lib/compile-route.js
@@ -12,13 +12,15 @@ function normalizeRequest(url, options, Request) {
 				const headers = {};
 				url.headers.forEach(name => (headers[name] = url.headers.name));
 				return headers;
-			})()
+			})(),
+			body: url.body
 		};
 	} else {
 		return {
 			url: url,
 			method: (options && options.method) || 'GET',
-			headers: options && options.headers
+			headers: options && options.headers,
+			body: options && options.body
 		};
 	}
 }


### PR DESCRIPTION
Added body to the normalized request in order to make it so that function matchers have the body contents available to be considered when routing