### PR TITLE
Support names that include capitals

### DIFF
--- a/src/lib/inspecting.js
+++ b/src/lib/inspecting.js
@@ -3,7 +3,7 @@ const FetchMock = {};
 const compileRoute = require('./compile-route');
 
 const isName = nameOrMatcher =>
-	typeof nameOrMatcher === 'string' && /^[\da-z\-]+$/.test(nameOrMatcher);
+	typeof nameOrMatcher === 'string' && /^[\da-zA-Z\-]+$/.test(nameOrMatcher);
 
 FetchMock.filterCallsWithMatcher = function(matcher, options = {}, calls) {
 	matcher = compileRoute(

--- a/test/specs/inspecting.test.js
+++ b/test/specs/inspecting.test.js
@@ -213,11 +213,16 @@ module.exports = fetchMock => {
 
 				it('can retrieve only calls handled by a named route', async () => {
 					fm.mock('http://it.at.here/', 200, { name: 'here' }).catch();
+					fm.mock('http://caps.it.at.here/', 200, {
+						name: 'hereWithCaps'
+					}).catch();
 
 					await fm.fetchHandler('http://it.at.here/', { method: 'post' });
 					await fm.fetchHandler('http://it.at.here/');
+					await fm.fetchHandler('http://caps.it.at.here/');
 					expect(fm.filterCalls('here', 'post').length).to.equal(1);
 					expect(fm.filterCalls('here', 'POST').length).to.equal(1);
+					expect(fm.filterCalls('hereWithCaps').length).to.equal(1);
 					expect(fm.filterCalls('here', 'POST')[0]).to.eql([
 						'http://it.at.here/',
 						{ method: 'post' }


### PR DESCRIPTION
This change allows names and identifiers to contain capitals, which is
fairly common behaviour for anyone who uses camelcase style when coding.