### PR TITLE
Remove node-fetch from peerDependencies since it is optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,5 @@
     "sinon-chai": "^2.14.0",
     "webpack": "^4.0.0",
     "webpack-cli": "^3.0.0"
-  },
-  "peerDependencies": {
-    "node-fetch": "*"
   }
 }


### PR DESCRIPTION
fetch-mock v7 added a peer dependency on `node-fetch`, however the package is not required for browser-based usages of fetch-mock. Such projects must then either install the dependency even if they don't use it, or else have peer dependency warnings be output by their package manager.

Hopefully in the future package managers will have a way to declare optional peer dependencies (eg yarnpkg/yarn#6487), so version ranges can be enforced iff people are using the dependency - but for now it's best to omit them from `peerDependencies` entirely.

Fixes #377.