### PR TITLE
Docs: Added a use case (mocking a request object in a test) to the tr…

### DIFF
--- a/docs/_troubleshooting/troubleshooting.md
+++ b/docs/_troubleshooting/troubleshooting.md
@@ -28,10 +28,10 @@ content_markdown: |-
   - For server side tests running in nodejs 0.12 or lower use `require('fetch-mock/es5/server')`
 
   ### Matching `Request` objects in node fails
-
-  In node, if using npm at a version less than 2 the `Request` constructor used by `fetch-mock` won't necessarily be the same as the one used by `node-fetch`. To fix this either:
-
-  - upgrade to npm@3
+  In node, if your `Request` object is not an instance of the `Request`
+  constructor used by fetch-mock, you need to set a reference to your custom
+  request class. This needs to be done if you are mocking the `Request` object
+  for a test or you are running npm with a version below 3.
   - use `fetchMock.config.Request = myRequest`, where `myRequest` is a reference to the Request constructor used in your application code.
 
 


### PR DESCRIPTION
I was writing some Node.js unit tests for my service-workers and kept getting the `Error: Unrecognised Request object`. This was caused by me mocking the `Request` object. I searched for a solution and read through the troubleshooting page. When I read about using npm version < 3 I skipped the rest of the document that could have given me the solution to my problem and spared me another 10 minutes. I hope my update makes it more clear for others running into the same problem.

Note that the troubleshooting section for the legacy npm version could probably be skipped entirely if you want to change the supported node version to >=5 at some point. https://nodejs.org/en/download/releases/.
```
"engines": {
  "node": >=5
}
```