### PR TITLE
tests to retrieve fetches to make sure header objects and header inst…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3328,11 +3328,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3345,15 +3347,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3456,7 +3461,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3466,6 +3472,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3478,17 +3485,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3505,6 +3515,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3577,7 +3588,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3587,6 +3599,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3692,6 +3705,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/test/specs/inspecting.test.js
+++ b/test/specs/inspecting.test.js
@@ -114,6 +114,34 @@ module.exports = fetchMock => {
 				expect(fm.filterCalls(true)[0][0]).to.equal('http://it.at.here/');
 			});
 
+			it('can retrieve calls with correct request options', async () => {
+				fm.mock('http://it.at.here/', 200).catch();
+
+				const options = {
+					method: 'GET',
+					headers: { foo: 'bar' }
+				};
+				const request = new Request('http://it.at.here/', options);
+				await fm.fetchHandler(request);
+				await fm.fetchHandler('http://it.at.where/');
+				const fetchOptions = fm.filterCalls(true)[0][1];
+				expect(fetchOptions).to.eql(options);
+			});
+
+			it('can retrieve calls with correct request options including header instance', async () => {
+				fm.mock('http://it.at.here/', 200).catch();
+				const options = {
+					method: 'GET',
+					headers: new Headers({ foo: 'bar' })
+				};
+				const request = new Request('http://it.at.here/', options);
+				await fm.fetchHandler(request);
+				await fm.fetchHandler('http://it.at.where/');
+				const { method, headers } = fm.filterCalls(true)[0][1];
+				expect(method).to.equal(options.method);
+				expect(headers.foo).to.equal('bar');
+			});
+
 			it('can retrieve only calls not matched by any route', async () => {
 				fm.mock('http://it.at.here/', 200).catch();
 


### PR DESCRIPTION
Hey, I created some tests because I ran into an issue described below. It turned out that in my mocked `headers` implementation, I was returning `Object.values()`  instead of `Object.entries()` in my `[Symbol.iterator]` function, causing some trouble on request normalization. Below is the issue for anyone running into the same problem. I was about to create the issue until I saw that the tests that were already there and the ones I added were passing and it was my implementation that was wrong. Feel free to merge the tests if you don't think they are already redundantly covered.


I'm running into a funny issue where my {key: value} header gets changed. The original key of my header is omitted while the first character of the value becomes the header key and the second character of the value becomes the new header value after the request gets normalized.
E.g if I were to pass `{'Authorization': 'JWT TOKEN'}` as a header object, it would be turned into `{ 'J': 'W' }` when retrieving the mocked fetch.
The problem seems to be the `headersToArray` function which is called before zipping the object. My mocked header object is an iterator; hence, the object gets spread into an array where the key is completely omitted. https://github.com/wheresrhys/fetch-mock/blob/dc7d5e2c7e58e3dd3f7610e08c6213044bc3eaca/src/lib/request-utils.js#L10
I'm not sure if there is something wrong with my mocked header implementation but if I'm not mistaken, [...headers]  will always simply return the values and no key, value pairs.
^ I was mistaken because I didn't understand iterables 😄