### PR TITLE
AbortError implementation

### DIFF
--- a/src/lib/fetch-handler.js
+++ b/src/lib/fetch-handler.js
@@ -2,6 +2,16 @@ const responseBuilder = require('./response-builder');
 const requestUtils = require('./request-utils');
 const FetchMock = {};
 
+class AbortError extends Error {
+	constructor() {
+		super(...arguments);
+		this.name = 'AbortError';
+
+		// Do not include this class in the stacktrace
+		Error.captureStackTrace(this, this.constructor);
+	}
+}
+
 const resolve = async (response, url, options, request) => {
 	// We want to allow things like
 	// - function returning a Promise for a response
@@ -41,7 +51,7 @@ FetchMock.fetchHandler = function(url, options, request) {
 	return new this.config.Promise((res, rej) => {
 		if (options && options.signal) {
 			const abort = () => {
-				rej(new Error(`URL '${url}' aborted.`));
+				rej(new AbortError(`URL '${url}' aborted.`));
 				done();
 			};
 			if (options.signal.aborted) {

--- a/test/specs/abortable.test.js
+++ b/test/specs/abortable.test.js
@@ -29,6 +29,7 @@ module.exports = fetchMock => {
 					signal: controller.signal
 				});
 			} catch (error) {
+				expect(error.name).to.equal('AbortError');
 				expect(error.message).to.equal("URL 'http://it.at.there/' aborted.");
 			}
 		});
@@ -44,6 +45,7 @@ module.exports = fetchMock => {
 					signal: controller.signal
 				});
 			} catch (error) {
+				expect(error.name).to.equal('AbortError');
 				expect(error.message).to.equal("URL 'http://it.at.there/' aborted.");
 			}
 		});


### PR DESCRIPTION
Fixes #416

Returns an AbortError instead of a plain Error when aborting a request