### PR TITLE
Fix link when docs aren't served from root

### DIFF
--- a/docs/_api-mocking/catch.md
+++ b/docs/_api-mocking/catch.md
@@ -6,7 +6,7 @@ description: |-
   Specifies how to respond to calls to `fetch` that don't match any mocks.
 parentMethodGroup: mocking
 content_markdown: |-
-  It accepts any valid [fetch-mock response](/#api-mockingmock_response), and can also take an arbitrary function to completely customise behaviour. If no argument is passed, then every unmatched call will receive a `200` response
+  It accepts any valid [fetch-mock response](#api-mockingmock_response), and can also take an arbitrary function to completely customise behaviour. If no argument is passed, then every unmatched call will receive a `200` response
 ---
 
 


### PR DESCRIPTION
e.g. http://www.wheresrhys.co.uk/fetch-mock/