### PR TITLE
Use babel transform runtime over babel polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1050,6 +1050,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
@@ -9693,7 +9694,8 @@
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "http://www.wheresrhys.co.uk/fetch-mock",
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
+    "babel-runtime": "^6.26.0",
     "glob-to-regexp": "^0.4.0",
     "path-to-regexp": "^2.2.1",
     "whatwg-url": "^6.5.0"

--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,7 @@
-require('babel-polyfill');
+require('babel-core').transform('code', {
+  plugins: ['transform-runtime']
+});
+
 const FetchMock = require('./lib/index');
 const statusTextMap = require('./lib/status-text');
 const theGlobal = typeof window !== 'undefined' ? window : self;

--- a/test/node6.js
+++ b/test/node6.js
@@ -2,7 +2,9 @@
 // transpiling all the tests, which muddies the waters a bit
 // So instead just making sure there are no syntax errors or issues with
 // missing globals or methods
-require('babel-polyfill');
+require('babel-core').transform('code', {
+  plugins: ['transform-runtime']
+});
 const fetchMock = require('../es5/server');
 
 fetchMock.mock('http://it.at.there/', 200);


### PR DESCRIPTION
### Problem
Projects that depend on babel-polyfill and fetch-mock will crash with the following [error](https://github.com/babel/babel/issues/4019).

### Solution

**In short:** Libraries should not be using babel-polyfill, but rather babel transform runtime.

### Additional Context
Babel team members warn that if you are writing a library - babel polyfill should not be used because it can pollute the globals used by project owners.

> If you are writing a library, you should not be using babel-polyfill. Having a library mutate the global state of the browser environment is not a good idea. If you need a standalone library you should be using babel-runtime via transform-runtime, or if you don't want to do that, you should make it a requirement that uses of your library load a polyfill first, and your code should assume it is there.             
>      
> Logan Smyth (member and contributor of babel) https://github.com/babel/babel/issues/4019#issuecomment-245409644

As such, Fetch-mock's improper use of babel is causing projects to crash in this fashion. https://github.com/babel/babel/issues/4019#issuecomment-245409644