### PR TITLE
Fixing dependent libs that need core-js@3 from breaking by adding a local dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "homepage": "http://www.wheresrhys.co.uk/fetch-mock",
   "dependencies": {
     "babel-polyfill": "^6.26.0",
+    "core-js": "^2.6.9",
     "glob-to-regexp": "^0.4.0",
     "path-to-regexp": "^2.2.1",
     "whatwg-url": "^6.5.0"


### PR DESCRIPTION
I know this seems counter intuitive, but by just adding the dependency of this library on core-js@2, you force NPM to install a local dependency "node_modules" folder which will use that version of core-js instead of using the dependents version.

This small change solved our dependency issue when we upgraded to core-js@3.

This fixes https://github.com/wheresrhys/fetch-mock/issues/419