### PR TITLE
Match json bodies

### DIFF
--- a/docs/_api-mocking/mock_options.md
+++ b/docs/_api-mocking/mock_options.md
@@ -1,5 +1,5 @@
 ---
-title: "options"
+title: 'options'
 position: 1.3
 description: |-
   An object containing further options for configuring mocking behaviour
@@ -28,15 +28,24 @@ parameters:
       - Headers
     content: |-
       Match only requests that have these headers set
-    examples: 
+    examples:
       - |-
         {"Accepts": "text/html"}
+  - name: body
+    types:
+      - Object
+      - Headers
+    content: |-
+      Match only requests that have this body (requires a `Content-Type` request header to be set to `application/json`)
+    examples:
+      - |-
+        {"JSON": "body"}
   - name: query
     types:
       - Object
     content: |-
       Match only requests that have these query parameters set (in any order)
-    examples: 
+    examples:
       - |-
         {"q": "cute+kittenz", "format": "gif"}
   - name: params
@@ -44,7 +53,7 @@ parameters:
       - Object
     content: |-
       When the `express:` keyword is used in a string matcher, match only requests with these express parameters
-    examples: 
+    examples:
       - |-
         {"section": "feed", "user": "geoff"}
   - name: functionMatcher

--- a/docs/_api-mocking/mock_options.md
+++ b/docs/_api-mocking/mock_options.md
@@ -34,12 +34,11 @@ parameters:
   - name: body
     types:
       - Object
-      - Headers
     content: |-
-      Match only requests that have this body (requires a `Content-Type` request header to be set to `application/json`)
+      Match only requests that send a JSON body with the exact structure and properties as the one provided here (also requires that the request has a `Content-Type` request header set to `application/json`)
     examples:
       - |-
-        {"JSON": "body"}
+        { "key1": "value1", "key2": "value2" }
   - name: query
     types:
       - Object

--- a/docs/_api-mocking/mock_options.md
+++ b/docs/_api-mocking/mock_options.md
@@ -35,7 +35,7 @@ parameters:
     types:
       - Object
     content: |-
-      Match only requests that send a JSON body with the exact structure and properties as the one provided here (also requires that the request has a `Content-Type` request header set to `application/json`)
+      Match only requests that send a JSON body with the exact structure and properties as the one provided here.
     examples:
       - |-
         { "key1": "value1", "key2": "value2" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5500,6 +5500,11 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-polyfill": "^6.26.0",
     "core-js": "^2.6.9",
     "glob-to-regexp": "^0.4.0",
+    "lodash.isequal": "^4.5.0",
     "path-to-regexp": "^2.2.1",
     "whatwg-url": "^6.5.0"
   },

--- a/src/lib/generate-matcher.js
+++ b/src/lib/generate-matcher.js
@@ -72,6 +72,18 @@ const getParamsMatcher = ({ params: expectedParams, matcher }) => {
 const getFunctionMatcher = ({ matcher, functionMatcher = () => true }) =>
 	typeof matcher === 'function' ? matcher : functionMatcher;
 
+const getBodyMatcher = ({ body: expectedBody }) => {
+	return (url, { headers = {}, body }) => {
+		const lowerCaseHeaders = headerUtils.toLowerCase(
+			headerUtils.normalize(headers)
+		);
+
+		return lowerCaseHeaders['content-type'] === 'application/json' && body
+			? body === JSON.stringify(expectedBody)
+			: false;
+	};
+};
+
 const getUrlMatcher = route => {
 	const { matcher, query } = route;
 
@@ -117,6 +129,7 @@ module.exports = route => {
 		route.method && getMethodMatcher(route),
 		route.headers && getHeaderMatcher(route),
 		route.params && getParamsMatcher(route),
+		route.body && getBodyMatcher(route),
 		getFunctionMatcher(route),
 		getUrlMatcher(route)
 	].filter(matcher => !!matcher);

--- a/src/lib/generate-matcher.js
+++ b/src/lib/generate-matcher.js
@@ -74,7 +74,12 @@ const getFunctionMatcher = ({ matcher, functionMatcher = () => true }) =>
 	typeof matcher === 'function' ? matcher : functionMatcher;
 
 const getBodyMatcher = ({ body: expectedBody }) => {
-	return (url, { headers = {}, body }) => {
+	return (url, { headers = {}, body, method = 'get' }) => {
+		if (method.toLowerCase() === 'get') {
+			// GET requests don’t send a body so the body matcher should be ignored for them
+			return true;
+		}
+
 		const lowerCaseHeaders = headerUtils.toLowerCase(
 			headerUtils.normalize(headers)
 		);

--- a/src/lib/generate-matcher.js
+++ b/src/lib/generate-matcher.js
@@ -7,6 +7,7 @@ const {
 	getQuery,
 	normalizeUrl
 } = require('./request-utils');
+const isEqual = require('lodash.isequal');
 
 const stringMatchers = {
 	begin: targetString => url => url.indexOf(targetString) === 0,
@@ -79,7 +80,7 @@ const getBodyMatcher = ({ body: expectedBody }) => {
 		);
 
 		return lowerCaseHeaders['content-type'] === 'application/json' && body
-			? body === JSON.stringify(expectedBody)
+			? isEqual(JSON.parse(body), expectedBody)
 			: false;
 	};
 };

--- a/src/lib/generate-matcher.js
+++ b/src/lib/generate-matcher.js
@@ -74,19 +74,13 @@ const getFunctionMatcher = ({ matcher, functionMatcher = () => true }) =>
 	typeof matcher === 'function' ? matcher : functionMatcher;
 
 const getBodyMatcher = ({ body: expectedBody }) => {
-	return (url, { headers = {}, body, method = 'get' }) => {
+	return (url, { body, method = 'get' }) => {
 		if (method.toLowerCase() === 'get') {
 			// GET requests don’t send a body so the body matcher should be ignored for them
 			return true;
 		}
 
-		const lowerCaseHeaders = headerUtils.toLowerCase(
-			headerUtils.normalize(headers)
-		);
-
-		return lowerCaseHeaders['content-type'] === 'application/json' && body
-			? isEqual(JSON.parse(body), expectedBody)
-			: false;
+		return body && isEqual(JSON.parse(body), expectedBody);
 	};
 };
 

--- a/src/lib/generate-matcher.js
+++ b/src/lib/generate-matcher.js
@@ -80,7 +80,13 @@ const getBodyMatcher = ({ body: expectedBody }) => {
 			return true;
 		}
 
-		return body && isEqual(JSON.parse(body), expectedBody);
+		let sentBody;
+
+		try {
+			sentBody = JSON.parse(body);
+		} catch (_) {}
+
+		return sentBody && isEqual(sentBody, expectedBody);
 	};
 };
 

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -553,29 +553,55 @@ module.exports = fetchMock => {
 			});
 
 			describe('body matching', () => {
-				it('should match against a JSON body', async () => {
+				it('should not match if no body provided in request', async () => {
 					fm.mock('http://it.at.there/', 200, { body: { foo: 'bar' } }).catch();
 
 					await fm.fetchHandler('http://it.at.there/', {
 						method: 'POST'
 					});
 					expect(fm.calls(true).length).to.equal(0);
-					await fm.fetchHandler('http://it.at.there/', {
-						method: 'POST',
-						body: JSON.stringify({ baz: 'blah' })
-					});
-					expect(fm.calls(true).length).to.equal(0);
+				});
+
+				it('should not match if the content type in request isn’t application/json', async () => {
+					fm.mock('http://it.at.there/', 200, { body: { foo: 'bar' } }).catch();
+
 					await fm.fetchHandler('http://it.at.there/', {
 						method: 'POST',
 						body: JSON.stringify({ foo: 'bar' })
 					});
 					expect(fm.calls(true).length).to.equal(0);
+				});
+
+				it('should not match if no body provided in request', async () => {
+					fm.mock('http://it.at.there/', 200, { body: { foo: 'bar' } }).catch();
+
+					await fm.fetchHandler('http://it.at.there/', {
+						method: 'POST',
+						body: JSON.stringify({ foo: 'bar' })
+					});
+					expect(fm.calls(true).length).to.equal(0);
+				});
+
+				it('should match if body sent matches expected body', async () => {
+					fm.mock('http://it.at.there/', 200, { body: { foo: 'bar' } }).catch();
+
 					await fm.fetchHandler('http://it.at.there/', {
 						method: 'POST',
 						body: JSON.stringify({ foo: 'bar' }),
 						headers: { 'Content-Type': 'application/json' }
 					});
 					expect(fm.calls(true).length).to.equal(1);
+				});
+
+				it('should not match if body sent doesn’t match expected body', async () => {
+					fm.mock('http://it.at.there/', 200, { body: { foo: 'bar' } }).catch();
+
+					await fm.fetchHandler('http://it.at.there/', {
+						method: 'POST',
+						body: JSON.stringify({ foo: 'woah!!!' }),
+						headers: { 'Content-Type': 'application/json' }
+					});
+					expect(fm.calls(true).length).to.equal(0);
 				});
 
 				it('should ignore the order of the keys in the body', async () => {

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -594,6 +594,17 @@ module.exports = fetchMock => {
 					expect(fm.calls(true).length).to.equal(0);
 				});
 
+				it('should not match if body sent isn’t JSON', async () => {
+					fm.mock('http://it.at.there/', 200, { body: { foo: 'bar' } }).catch();
+
+					await fm.fetchHandler('http://it.at.there/', {
+						method: 'POST',
+						body: new ArrayBuffer(8),
+						headers: { 'Content-Type': 'application/json' }
+					});
+					expect(fm.calls(true).length).to.equal(0);
+				});
+
 				it('should ignore the order of the keys in the body', async () => {
 					fm.mock('http://it.at.there/', 200, {
 						body: {

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -572,16 +572,6 @@ module.exports = fetchMock => {
 					expect(fm.calls(true).length).to.equal(0);
 				});
 
-				it('should not match if no body provided in request', async () => {
-					fm.mock('http://it.at.there/', 200, { body: { foo: 'bar' } }).catch();
-
-					await fm.fetchHandler('http://it.at.there/', {
-						method: 'POST',
-						body: JSON.stringify({ foo: 'bar' })
-					});
-					expect(fm.calls(true).length).to.equal(0);
-				});
-
 				it('should match if body sent matches expected body', async () => {
 					fm.mock('http://it.at.there/', 200, { body: { foo: 'bar' } }).catch();
 

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -622,6 +622,18 @@ module.exports = fetchMock => {
 					});
 					expect(fm.calls(true).length).to.equal(1);
 				});
+
+				it('should ignore the body option matcher if request was GET', async () => {
+					fm.mock('http://it.at.there/', 200, {
+						body: {
+							foo: 'bar',
+							baz: 'qux'
+						}
+					}).catch();
+
+					await fm.fetchHandler('http://it.at.there/');
+					expect(fm.calls(true).length).to.equal(1);
+				});
 			});
 		});
 

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -551,6 +551,33 @@ module.exports = fetchMock => {
 					});
 				});
 			});
+
+			describe('body matching', () => {
+				it('should match against a JSON body', async () => {
+					fm.mock('http://it.at.there/', 200, { body: { foo: 'bar' } }).catch();
+
+					await fm.fetchHandler('http://it.at.there/', {
+						method: 'POST'
+					});
+					expect(fm.calls(true).length).to.equal(0);
+					await fm.fetchHandler('http://it.at.there/', {
+						method: 'POST',
+						body: JSON.stringify({ baz: 'blah' })
+					});
+					expect(fm.calls(true).length).to.equal(0);
+					await fm.fetchHandler('http://it.at.there/', {
+						method: 'POST',
+						body: JSON.stringify({ foo: 'bar' })
+					});
+					expect(fm.calls(true).length).to.equal(0);
+					await fm.fetchHandler('http://it.at.there/', {
+						method: 'POST',
+						body: JSON.stringify({ foo: 'bar' }),
+						headers: { 'Content-Type': 'application/json' }
+					});
+					expect(fm.calls(true).length).to.equal(1);
+				});
+			});
 		});
 
 		describe('multiple routes', () => {

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -562,14 +562,14 @@ module.exports = fetchMock => {
 					expect(fm.calls(true).length).to.equal(0);
 				});
 
-				it('should not match if the content type in request isn’t application/json', async () => {
+				it('should match if no content type is specified', async () => {
 					fm.mock('http://it.at.there/', 200, { body: { foo: 'bar' } }).catch();
 
 					await fm.fetchHandler('http://it.at.there/', {
 						method: 'POST',
 						body: JSON.stringify({ foo: 'bar' })
 					});
-					expect(fm.calls(true).length).to.equal(0);
+					expect(fm.calls(true).length).to.equal(1);
 				});
 
 				it('should match if body sent matches expected body', async () => {

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -577,6 +577,25 @@ module.exports = fetchMock => {
 					});
 					expect(fm.calls(true).length).to.equal(1);
 				});
+
+				it('should ignore the order of the keys in the body', async () => {
+					fm.mock('http://it.at.there/', 200, {
+						body: {
+							foo: 'bar',
+							baz: 'qux'
+						}
+					}).catch();
+
+					await fm.fetchHandler('http://it.at.there/', {
+						method: 'POST',
+						body: JSON.stringify({
+							baz: 'qux',
+							foo: 'bar'
+						}),
+						headers: { 'Content-Type': 'application/json' }
+					});
+					expect(fm.calls(true).length).to.equal(1);
+				});
 			});
 		});
 


### PR DESCRIPTION
This PR allows for matching against JSON bodies. It adds the ability to add a `body` value in the options parameter which, when set, will match against requests with a `"Content-Type": "application/json"` header set.

### Example Usage

```js
fetchMock.mock('http://example.com/', 200, { body: { foo: 'bar' } })

fetch('http://example.com/', {
	method: 'POST',
	headers: {
		'Content-Type': 'application/json'
	},
	body: JSON.stringify({foo: 'bar'})
})

```

Addresses #442 