### PR TITLE
Adds node-fetch to the peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,11 @@
   "peerDependencies": {
     "node-fetch": "*"
   },
+  "peerDependenciesMeta": {
+    "node-fetch": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
     "path-to-regexp": "^2.2.1",
     "whatwg-url": "^6.5.0"
   },
+  "peerDependencies": {
+    "node-fetch": "*"
+  },
   "engines": {
     "node": ">=4.0.0"
   },


### PR DESCRIPTION
The `node-fetch` package is required here:

https://github.com/wheresrhys/fetch-mock/blob/master/src/server.js#L1

But isn't properly listed in the peer dependencies (it's only a dev dependencies). This may lead to non-deterministic installs, and will be purely disallowed in future Yarn releases.