### PR TITLE
Check for Error.captureStackTrace before using it

### DIFF
--- a/src/lib/fetch-handler.js
+++ b/src/lib/fetch-handler.js
@@ -11,7 +11,9 @@ class AbortError extends Error {
 		this.message = 'The operation was aborted.';
 
 		// Do not include this class in the stacktrace
-		Error.captureStackTrace(this, this.constructor);
+		if (Error.captureStackTrace) {
+			Error.captureStackTrace(this, this.constructor);
+		}
 	}
 }
 


### PR DESCRIPTION
Error.captureStackTrace is a V8-ism so we should check if it exists
before trying to use it or else it will fail in non-Chromium browsers.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types

Fixes #447.