### PR TITLE
fix(abort): no abort if signal was in request

### DIFF
--- a/src/lib/fetch-handler.js
+++ b/src/lib/fetch-handler.js
@@ -62,15 +62,16 @@ FetchMock.fetchHandler = function(url, options, request) {
 	// wrapped in this promise to make sure we respect custom Promise
 	// constructors defined by the user
 	return new this.config.Promise((res, rej) => {
-		if (options && options.signal) {
+		const signal = (options && options.signal) || (request && request.signal);
+		if (signal) {
 			const abort = () => {
 				rej(new AbortError());
 				done();
 			};
-			if (options.signal.aborted) {
+			if (signal.aborted) {
 				abort();
 			}
-			options.signal.addEventListener('abort', abort);
+			signal.addEventListener('abort', abort);
 		}
 
 		this.generateResponse(route, url, options, request)

--- a/src/lib/fetch-handler.js
+++ b/src/lib/fetch-handler.js
@@ -62,7 +62,7 @@ FetchMock.fetchHandler = function(url, options, request) {
 	// wrapped in this promise to make sure we respect custom Promise
 	// constructors defined by the user
 	return new this.config.Promise((res, rej) => {
-		const signal = (options && options.signal) || (request && request.signal);
+		const signal = options && options.signal;
 		if (signal) {
 			const abort = () => {
 				rej(new AbortError());

--- a/src/lib/request-utils.js
+++ b/src/lib/request-utils.js
@@ -43,7 +43,8 @@ module.exports = {
 				url: normalizeUrl(url.url),
 				options: Object.assign(
 					{
-						method: url.method
+						method: url.method,
+						signal: url.signal
 					},
 					options
 				),

--- a/test/runner.js
+++ b/test/runner.js
@@ -5,10 +5,10 @@ module.exports = (fetchMock, theGlobal, fetch, AbortController) => {
 		require('./specs/sandbox.test')(fetchMock, theGlobal);
 		require('./specs/routing.test')(fetchMock);
 		require('./specs/responses.test')(fetchMock);
-		require('./specs/inspecting.test')(fetchMock);
+		require('./specs/inspecting.test')(fetchMock, theGlobal);
 		require('./specs/repeat.test')(fetchMock);
 		require('./specs/custom-implementations.test')(fetchMock);
 		require('./specs/options.test')(fetchMock, theGlobal, fetch);
-		require('./specs/abortable.test')(fetchMock, AbortController, theGlobal, fetch);
+		require('./specs/abortable.test')(fetchMock, AbortController);
 	});
 };

--- a/test/runner.js
+++ b/test/runner.js
@@ -9,6 +9,6 @@ module.exports = (fetchMock, theGlobal, fetch, AbortController) => {
 		require('./specs/repeat.test')(fetchMock);
 		require('./specs/custom-implementations.test')(fetchMock);
 		require('./specs/options.test')(fetchMock, theGlobal, fetch);
-		require('./specs/abortable.test')(fetchMock, AbortController);
+		require('./specs/abortable.test')(fetchMock, AbortController, theGlobal, fetch);
 	});
 };

--- a/test/specs/abortable.test.js
+++ b/test/specs/abortable.test.js
@@ -1,23 +1,9 @@
 const chai = require('chai');
 const expect = chai.expect;
 
-module.exports = (fetchMock, AbortController, theGlobal, fetch) => {
+module.exports = (fetchMock, AbortController) => {
 	(AbortController ? describe : describe.skip)('abortable fetch', () => {
 		let fm;
-		let noNativeRequest = false;
-		before(() => {
-			noNativeRequest = !theGlobal.Request;
-			if (noNativeRequest) {
-				theGlobal.Request = fetch.Request;
-			}
-		});
-
-		after(() => {
-			if (noNativeRequest) {
-				delete theGlobal.Request;
-			}
-		});
-
 		beforeEach(() => {
 			fm = fetchMock.createInstance();
 		});
@@ -57,7 +43,7 @@ module.exports = (fetchMock, AbortController, theGlobal, fetch) => {
 			setTimeout(() => controller.abort(), 300);
 
 			try {
-				await fm.fetchHandler('http://it.at.there/', {}, new Request('http://it.at.there/', { signal: controller.signal }));
+				await fm.fetchHandler(new fm.config.Request('http://it.at.there/', { signal: controller.signal }));
 			} catch (error) {
 				console.error(error);
 				expect(error.name).to.equal('AbortError');


### PR DESCRIPTION
Thank you for this awesome library. This made my testing almost effortless :)

During testing I have seen that the `abort` only works if the signal is passed as an option, like below.

```javascript
const response = await (await fetch(resourceUrl, { signal })).json();
```

However, if the signal is passed on as a part of the `Request` object, like below, the `abort` event has no effect.

```javascript
const request = new Request(resourceUrl, { signal });
const response = await (await fetch(request)).json();
```

In this PR, I fixed this issue. I have added a test that runs both in browser and node.

Would be great if you can review, merge, and publish this fix. In case of any issue, please let me know