### PR TITLE
fix(abort): throwing DOMEXception when available

### DIFF
--- a/src/lib/fetch-handler.js
+++ b/src/lib/fetch-handler.js
@@ -68,7 +68,8 @@ FetchMock.fetchHandler = function(url, options, request) {
 	return new this.config.Promise((res, rej) => {
 		if (signal) {
 			const abort = () => {
-				rej(new AbortError());
+				// note that DOMException is not available in node.js; even node-fetch uses a custom error class: https://github.com/bitinn/node-fetch/blob/master/src/abort-error.js
+				rej(typeof DOMException !== 'undefined' ? new DOMException('The operation was aborted.', 'AbortError') : new AbortError());
 				done();
 			};
 			if (signal.aborted) {

--- a/test/specs/abortable.test.js
+++ b/test/specs/abortable.test.js
@@ -25,6 +25,9 @@ module.exports = (fetchMock, AbortController) => {
 					signal: controller.signal
 				});
 			} catch (error) {
+				if (typeof DOMException !== 'undefined') {
+					expect(error instanceof DOMException).to.equal(true);
+				}
 				expect(error.name).to.equal('AbortError');
 				expect(error.message).to.equal('The operation was aborted.');
 			}
@@ -49,6 +52,9 @@ module.exports = (fetchMock, AbortController) => {
 					})
 				);
 			} catch (error) {
+				if (typeof DOMException !== 'undefined') {
+					expect(error instanceof DOMException).to.equal(true);
+				}
 				console.error(error);
 				expect(error.name).to.equal('AbortError');
 				expect(error.message).to.equal('The operation was aborted.');
@@ -66,6 +72,9 @@ module.exports = (fetchMock, AbortController) => {
 					signal: controller.signal
 				});
 			} catch (error) {
+				if (typeof DOMException !== 'undefined') {
+					expect(error instanceof DOMException).to.equal(true);
+				}
 				expect(error.name).to.equal('AbortError');
 				expect(error.message).to.equal('The operation was aborted.');
 			}
@@ -87,6 +96,9 @@ module.exports = (fetchMock, AbortController) => {
 					signal: controller.signal
 				});
 			} catch (error) {
+				if (typeof DOMException !== 'undefined') {
+					expect(error instanceof DOMException).to.equal(true);
+				}
 				expect(fm.done()).to.be.true;
 			}
 		});


### PR DESCRIPTION
As per spec when a fetch is aborted a DOMException is thrown with name 'AbortError'. However, the current implemnetation threw a custom error instance.  That should work for node.js due to unavailibility of DOMException. This commit ensures that when DOMException is available it is thrown instead.

Related: #416