### PR TITLE
No mjs

### DIFF
--- a/docs/_usage/importing.md
+++ b/docs/_usage/importing.md
@@ -9,7 +9,7 @@ content_markdown: |-
   #### Built files
   In general `server` refers to the version of the source code designed for running in nodejs, whereas `client` refers to the version designed to run in the browser. As well as this distinction, fetch-mock builds several versions of itself:
   - `/cjs` directory - this contains a copy of the source files (which are currently written as commonjs modules). They are copied here in order to prevent direct requires from `/src`, which could make migrating the src to ES modules troublesome. `client.js` and `server.js` are the entry points. The directory also contains a `package.json` file specifying that the directory contains commonjs modules.
-  - `/esm` directory - This contains builds of fetch-mock, exported as ES modules. `client.mjs` and `server.mjs` are the entry points. The bundling tool used is [rollup](https://rollupjs.org).
+  - `/esm` directory - This contains builds of fetch-mock, exported as ES modules. `client.js` and `server.js` are the entry points. The bundling tool used is [rollup](https://rollupjs.org).
   - `/es5` directory - This contains builds of fetch-mock which do not use any JS syntax not included in the [ES5 standard](https://es5.github.io/), i.e. excludes recent additions to the language. It contains 4 entry points:
     - `client.js` and `server.js`, both of which are commonjs modules
     - `client-legacy.js`, which is the same as `client.js`, but includes some babel polyfill bootstrapping to ease running it in older environments

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "description": "Mock http requests made using fetch (or isomorphic-fetch)",
   "main": "./cjs/server.js",
-  "browser": "./esm/client.mjs",
-  "module": "./esm/server.mjs",
+  "browser": "./esm/client.js",
+  "module": "./esm/server.js",
   "types": "./types/index.d.ts",
   "scripts": {
     "test": "make lint test",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,11 @@ export default [
 			file: 'esm/client.js',
 			format: 'esm'
 		},
-		plugins: [resolve({ preferBuiltins: false }), commonjs()]
+		plugins: [
+			resolve({ preferBuiltins: false, browser: true }),
+			commonjs(),
+			builtins()
+		]
 	},
 	{
 		input: 'src/server.js',
@@ -44,7 +48,7 @@ export default [
 		},
 		plugins: [
 			json(),
-			resolve({ preferBuiltins: false }),
+			resolve({ preferBuiltins: false, browser: true }),
 			commonjs(),
 			builtins(),
 			globals()

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ export default [
 	{
 		input: 'src/client.js',
 		output: {
-			file: 'esm/client.mjs',
+			file: 'esm/client.js',
 			format: 'esm'
 		},
 		plugins: [resolve({ preferBuiltins: false }), commonjs()]
@@ -16,7 +16,7 @@ export default [
 	{
 		input: 'src/server.js',
 		output: {
-			file: 'esm/server.mjs',
+			file: 'esm/server.js',
 			format: 'esm'
 		},
 		plugins: [


### PR DESCRIPTION
Compatibility issues are rife using .mjs - the internet is clearly not as ready for esm as some bloggers would have us believe.

Reverting to .js until all the test runners have updated their regexes and globs