### PR TITLE
implement partial body matching

### DIFF
--- a/docs/_api-mocking/mock_matcher.md
+++ b/docs/_api-mocking/mock_matcher.md
@@ -136,6 +136,10 @@ parameters:
         examples:
           - |-
             { "key1": "value1", "key2": "value2" }
+      - name: matchPartialBody
+        types:
+          - Boolean
+        content: Match calls that only partially match a specified body json. See [global configuration](#usageconfiguration) for details.
       - name: query
         types:
           - Object

--- a/docs/_usage/configuration.md
+++ b/docs/_usage/configuration.md
@@ -38,6 +38,10 @@ parameters:
       - `undefined`: An error will be thrown
       - `true`: Overwrites the existing route
       - `false`: Appends the new route to the list of routes
+  - name: matchPartialBody
+    types:
+      - Boolean
+    content: Match calls that only partially match a specified body json. Uses the [is-subset](https://www.npmjs.com/package/is-subset) library under the hood, which implements behaviour the same as jest's [.objectContainig()](https://jestjs.io/docs/en/expect#expectobjectcontainingobject) method. 
   - name: warnOnFallback
     default: true
     types:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4767,6 +4767,11 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "core-js": "^3.0.0",
     "debug": "^4.1.1",
     "glob-to-regexp": "^0.4.0",
+    "is-subset": "^0.1.1",
     "lodash.isequal": "^4.5.0",
     "path-to-regexp": "^2.2.1",
     "querystring": "^0.2.0",

--- a/src/lib/compile-route.js
+++ b/src/lib/compile-route.js
@@ -121,7 +121,7 @@ const compileRoute = function(args) {
 	debug('Compiling route');
 	const route = sanitizeRoute(argsToRoute(args));
 	validateRoute(route);
-	route.matcher = generateMatcher(route);
+	route.matcher = generateMatcher(route, this);
 	limit(route);
 	delayResponse(route);
 	return route;

--- a/src/lib/fetch-handler.js
+++ b/src/lib/fetch-handler.js
@@ -138,7 +138,7 @@ FetchMock.fetchHandler.isMock = true;
 FetchMock.executeRouter = function(url, options, request) {
 	const debug = getDebug('executeRouter()');
 	debug(`Attempting to match request to a route`);
-	if (this.config.fallbackToNetwork === 'always') {
+	if (this.getOption('fallbackToNetwork') === 'always') {
 		debug(
 			'  Configured with fallbackToNetwork=always - passing through to fetch'
 		);
@@ -152,7 +152,7 @@ FetchMock.executeRouter = function(url, options, request) {
 		return match;
 	}
 
-	if (this.config.warnOnFallback) {
+	if (this.getOption('warnOnFallback')) {
 		console.warn(`Unmatched ${(options && options.method) || 'GET'} to ${url}`); // eslint-disable-line
 	}
 
@@ -163,7 +163,7 @@ FetchMock.executeRouter = function(url, options, request) {
 		return { response: this.fallbackResponse };
 	}
 
-	if (!this.config.fallbackToNetwork) {
+	if (!this.getOption('fallbackToNetwork')) {
 		throw new Error(
 			`fetch-mock: No fallback response defined for ${(options &&
 				options.method) ||

--- a/src/lib/generate-matcher.js
+++ b/src/lib/generate-matcher.js
@@ -116,14 +116,10 @@ const getParamsMatcher = ({ params: expectedParams, url: matcherUrl }) => {
 	};
 };
 
-const getBodyMatcher = (
-	{ body: expectedBody, matchPartialBody },
-	fetchMock
-) => {
-	matchPartialBody =
-		typeof matchPartialBody !== 'undefined'
-			? matchPartialBody
-			: fetchMock.config.matchPartialBody || false;
+const getBodyMatcher = (route, fetchMock) => {
+	const matchPartialBody = fetchMock.getOption('matchPartialBody', route);
+	const { body: expectedBody } = route;
+
 	debug('Generating body matcher');
 	return (url, { body, method = 'get' }) => {
 		debug('Attempting to match body');

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -53,4 +53,8 @@ FetchMock.sandbox = function() {
 	return sandbox;
 };
 
+FetchMock.getOption = function(name, route = {}) {
+	return name in route ? route[name] : this.config[name];
+};
+
 module.exports = FetchMock;

--- a/src/lib/response-builder.js
+++ b/src/lib/response-builder.js
@@ -94,7 +94,7 @@ e.g. {"body": {"status: "registered"}}`);
 	}
 
 	getOption(name) {
-		return name in this.route ? this.route[name] : this.fetchMock.config[name];
+		return this.fetchMock.getOption(name, this.route);
 	}
 
 	convertToJson() {

--- a/src/lib/set-up-and-tear-down.js
+++ b/src/lib/set-up-and-tear-down.js
@@ -20,17 +20,12 @@ FetchMock.addRoute = function(uncompiledRoute) {
 			(!method || !route.method || method === route.method)
 	);
 
-	const overwriteRoutes =
-		'overwriteRoutes' in route
-			? route.overwriteRoutes
-			: this.config.overwriteRoutes;
-
-	if (overwriteRoutes === false || !clashes.length) {
+	if (this.getOption('overwriteRoutes', route) === false || !clashes.length) {
 		this._uncompiledRoutes.push(uncompiledRoute);
 		return this.routes.push(route);
 	}
 
-	if (overwriteRoutes === true) {
+	if (this.getOption('overwriteRoutes', route) === true) {
 		clashes.forEach(clash => {
 			const index = this.routes.indexOf(clash);
 			this._uncompiledRoutes.splice(index, 1, uncompiledRoute);

--- a/test/specs/matcher-object.test.js
+++ b/test/specs/matcher-object.test.js
@@ -152,5 +152,16 @@ module.exports = fetchMock => {
 			const res = await fm.fetchHandler('http://it.at.there/');
 			expect(res.status).to.equal(300);
 		});
+
+		it('support setting matchPartialBody on matcher parameter', async () => {
+			fm.mock({ body: { ham: 'sandwich' }, matchPartialBody: true }, 200).catch(
+				404
+			);
+			const res = await fm.fetchHandler('http://it.at.there', {
+				method: 'POST',
+				body: JSON.stringify({ ham: 'sandwich', egg: 'mayonaise' })
+			});
+			expect(res.status).to.equal(200);
+		});
 	});
 };

--- a/test/specs/options.test.js
+++ b/test/specs/options.test.js
@@ -155,6 +155,55 @@ module.exports = (fetchMock, theGlobal, fetch) => {
 			});
 		});
 
+		describe('matchPartialBody', () => {
+			it("don't match partial bodies by default", async () => {
+				fm.mock({ body: { ham: 'sandwich' } }, 200).catch(404);
+				const res = await fm.fetchHandler('http://it.at.there', {
+					method: 'POST',
+					body: JSON.stringify({ ham: 'sandwich', egg: 'mayonaise' })
+				});
+				expect(res.status).to.equal(404);
+			});
+
+			it('match partial bodies when configured true', async () => {
+				fm.config.matchPartialBody = true;
+				fm.mock({ body: { ham: 'sandwich' } }, 200).catch(404);
+				const res = await fm.fetchHandler('http://it.at.there', {
+					method: 'POST',
+					body: JSON.stringify({ ham: 'sandwich', egg: 'mayonaise' })
+				});
+				expect(res.status).to.equal(200);
+				fm.config.matchPartialBody = false;
+			});
+
+			it('local setting can override to false', async () => {
+				fm.config.matchPartialBody = true;
+				fm.mock(
+					{ body: { ham: 'sandwich' }, matchPartialBody: false },
+					200
+				).catch(404);
+				const res = await fm.fetchHandler('http://it.at.there', {
+					method: 'POST',
+					body: JSON.stringify({ ham: 'sandwich', egg: 'mayonaise' })
+				});
+				expect(res.status).to.equal(404);
+				fm.config.matchPartialBody = false;
+			});
+
+			it('local setting can override to true', async () => {
+				fm.config.matchPartialBody = false;
+				fm.mock(
+					{ body: { ham: 'sandwich' }, matchPartialBody: true },
+					200
+				).catch(404);
+				const res = await fm.fetchHandler('http://it.at.there', {
+					method: 'POST',
+					body: JSON.stringify({ ham: 'sandwich', egg: 'mayonaise' })
+				});
+				expect(res.status).to.equal(200);
+			});
+		});
+
 		describe.skip('warnOnFallback', () => {
 			it('warn on fallback response by default', async () => {});
 			it("don't warn on fallback response when configured false", async () => {});

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -654,6 +654,70 @@ module.exports = fetchMock => {
 					await fm.fetchHandler('http://it.at.there/');
 					expect(fm.calls(true).length).to.equal(1);
 				});
+
+				describe('partial body matching', () => {
+					it('match when missing properties', async () => {
+						fm.mock(
+							{ body: { ham: 'sandwich' }, matchPartialBody: true },
+							200
+						).catch(404);
+						const res = await fm.fetchHandler('http://it.at.there', {
+							method: 'POST',
+							body: JSON.stringify({ ham: 'sandwich', egg: 'mayonaise' })
+						});
+						expect(res.status).to.equal(200);
+					});
+
+					it('match when missing nested properties', async () => {
+						fm.mock(
+							{ body: { meal: { ham: 'sandwich' } }, matchPartialBody: true },
+							200
+						).catch(404);
+						const res = await fm.fetchHandler('http://it.at.there', {
+							method: 'POST',
+							body: JSON.stringify({
+								meal: { ham: 'sandwich', egg: 'mayonaise' }
+							})
+						});
+						expect(res.status).to.equal(200);
+					});
+
+					it('not match when properties at wrong indentation', async () => {
+						fm.mock(
+							{ body: { ham: 'sandwich' }, matchPartialBody: true },
+							200
+						).catch(404);
+						const res = await fm.fetchHandler('http://it.at.there', {
+							method: 'POST',
+							body: JSON.stringify({ meal: { ham: 'sandwich' } })
+						});
+						expect(res.status).to.equal(404);
+					});
+
+					it('match when starting subset of array', async () => {
+						fm.mock(
+							{ body: { ham: [1, 2] }, matchPartialBody: true },
+							200
+						).catch(404);
+						const res = await fm.fetchHandler('http://it.at.there', {
+							method: 'POST',
+							body: JSON.stringify({ ham: [1, 2, 3] })
+						});
+						expect(res.status).to.equal(200);
+					});
+
+					it('not match when not starting subset of array', async () => {
+						fm.mock(
+							{ body: { ham: [1, 3] }, matchPartialBody: true },
+							200
+						).catch(404);
+						const res = await fm.fetchHandler('http://it.at.there', {
+							method: 'POST',
+							body: JSON.stringify({ ham: [1, 2, 3] })
+						});
+						expect(res.status).to.equal(404);
+					});
+				});
 			});
 		});
 


### PR DESCRIPTION
This allows matching even when only specifying some parts of the request body. Like jest object matching