### PR TITLE
Any

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Mock http requests made using [fetch](https://developer.mozilla.org/en-US/docs/W
 Features include:
 
 - helpers for all common http methods and for responding a limited number of times
-- declarative matching for most aspects of a http request 
+- declarative matching for most aspects of a http request
 - delayed responses
 - spying on real network requests
 - support for advanced fetch behaviours, such as streaming responses and aborting
 
-*New* If using jest, try the new [fetch-mock-jest](https://www.npmjs.com/package/fetch-mock-jest) wrapper.
+_New_ If using jest, try the new [fetch-mock-jest](https://www.npmjs.com/package/fetch-mock-jest) wrapper.
 
 ![node version](https://img.shields.io/node/v/fetch-mock.svg?style=flat-square)
 [![licence](https://img.shields.io/npm/l/fetch-mock.svg?style=flat-square)](https://github.com/wheresrhys/fetch-mock/blob/master/LICENSE)

--- a/docs/_api-mocking/catch.md
+++ b/docs/_api-mocking/catch.md
@@ -1,7 +1,7 @@
 ---
 title: ".catch(response)"
 navTitle: .catch()
-position: 5
+position: 8
 description: |-
   Specifies how to respond to calls to `fetch` that don't match any mocks.
 parentMethodGroup: mocking

--- a/docs/_api-mocking/getAnyOnce_postAnyOnce.md
+++ b/docs/_api-mocking/getAnyOnce_postAnyOnce.md
@@ -1,0 +1,8 @@
+---
+title: ".getAnyOnce(), .postAnyOnce(), .putAnyOnce(), .deleteAnyOnce(), .headAnyOnce(), .patchAnyOnce()"
+navTitle: .getAnyOnce(), .postAnyOnce() ...
+position: 3
+description: |-
+  Shorthands for `anyOnce()` that only respond to requests using a particular http method.
+parentMethodGroup: mocking
+---

--- a/docs/_api-mocking/getAnyOnce_postAnyOnce.md
+++ b/docs/_api-mocking/getAnyOnce_postAnyOnce.md
@@ -1,7 +1,7 @@
 ---
 title: ".getAnyOnce(), .postAnyOnce(), .putAnyOnce(), .deleteAnyOnce(), .headAnyOnce(), .patchAnyOnce()"
 navTitle: .getAnyOnce(), .postAnyOnce() ...
-position: 3
+position: 7
 description: |-
   Shorthands for `anyOnce()` that only respond to requests using a particular http method.
 parentMethodGroup: mocking

--- a/docs/_api-mocking/getAny_postAny.md
+++ b/docs/_api-mocking/getAny_postAny.md
@@ -1,7 +1,7 @@
 ---
 title: ".getAny(), .postAny(), .putAny(), .deleteAny(), .headAny(), .patchAny()"
 navTitle: .getAny(), .postAny() ...
-position: 3
+position: 5.5
 description: |-
   Shorthands for `any()` that only respond to requests using a particular http method.
 parentMethodGroup: mocking

--- a/docs/_api-mocking/getAny_postAny.md
+++ b/docs/_api-mocking/getAny_postAny.md
@@ -1,0 +1,8 @@
+---
+title: ".getAny(), .postAny(), .putAny(), .deleteAny(), .headAny(), .patchAny()"
+navTitle: .getAny(), .postAny() ...
+position: 3
+description: |-
+  Shorthands for `any()` that only respond to requests using a particular http method.
+parentMethodGroup: mocking
+---

--- a/docs/_api-mocking/get_post.md
+++ b/docs/_api-mocking/get_post.md
@@ -1,7 +1,7 @@
 ---
 title: ".get(), .post(), .put(), .delete(), .head(), .patch()"
 navTitle: .get(), .post() ...
-position: 3
+position: 2
 description: |-
   Shorthands for `mock()` that create routes that only respond to requests using a particular http method.
 parentMethodGroup: mocking

--- a/docs/_api-mocking/mock.md
+++ b/docs/_api-mocking/mock.md
@@ -1,7 +1,7 @@
 ---
 title: ".mock(matcher, response, options)"
 navTitle: .mock()
-position: 1.0
+position: 1
 description: |
   Initialises or extends a stub implementation of fetch, applying a `route` that matches `matcher`, delivers a `Response` configured using `response`, and that respects the additional `options`. The stub will record its calls so they can be inspected later. If `.mock` is called on the top level `fetch-mock` instance, this stub function will also replace `fetch` globally. Calling `.mock()` with no arguments will carry out this stubbing without defining any mock responses.
 

--- a/docs/_api-mocking/mock_any.md
+++ b/docs/_api-mocking/mock_any.md
@@ -1,6 +1,7 @@
 ---
 title: ".any(response, options)"
-position: 2
+navTitle: .any()
+position: 5
 description: |-
   Shorthand for `mock()` which creates a route that will return a response to any fetch request.
 parentMethodGroup: mocking

--- a/docs/_api-mocking/mock_any.md
+++ b/docs/_api-mocking/mock_any.md
@@ -1,0 +1,7 @@
+---
+title: ".any(response, options)"
+position: 2
+description: |-
+  Shorthand for `mock()` which creates a route that will return a response to any fetch request.
+parentMethodGroup: mocking
+---

--- a/docs/_api-mocking/mock_any_once.md
+++ b/docs/_api-mocking/mock_any_once.md
@@ -1,6 +1,7 @@
 ---
 title: ".anyOnce(response, options)"
-position: 2
+navTitle: .anyOnce()
+position: 6
 description: |-
   Shorthand for `mock()` which creates a route that will return a response to any single fetch request.
 parentMethodGroup: mocking

--- a/docs/_api-mocking/mock_any_once.md
+++ b/docs/_api-mocking/mock_any_once.md
@@ -1,0 +1,7 @@
+---
+title: ".anyOnce(response, options)"
+position: 2
+description: |-
+  Shorthand for `mock()` which creates a route that will return a response to any single fetch request.
+parentMethodGroup: mocking
+---

--- a/docs/_api-mocking/mock_once.md
+++ b/docs/_api-mocking/mock_once.md
@@ -1,6 +1,6 @@
 ---
 title: ".once()"
-position: 2
+position: 3
 description: |-
   Shorthand for `mock()` which creates a route that can only mock a single request. (see `repeat` option above)
 parentMethodGroup: mocking

--- a/docs/_api-mocking/spy.md
+++ b/docs/_api-mocking/spy.md
@@ -1,7 +1,7 @@
 ---
 title: ".spy()"
 navTitle: .spy()
-position: 6
+position: 9
 description: |-
   Records call history while passing each call on to `fetch` to be handled by the network
 parentMethodGroup: mocking

--- a/src/lib/set-up-and-tear-down.js
+++ b/src/lib/set-up-and-tear-down.js
@@ -97,6 +97,7 @@ defineGreedyShorthand('any', 'mock');
 ['get', 'post', 'put', 'delete', 'head', 'patch'].forEach(method => {
 	defineShorthand(method, 'mock', { method });
 	defineShorthand(`${method}Once`, 'once', { method });
+	defineGreedyShorthand(`${method}Any`, method, { method });
 });
 
 FetchMock.resetBehavior = function() {

--- a/src/lib/set-up-and-tear-down.js
+++ b/src/lib/set-up-and-tear-down.js
@@ -97,7 +97,8 @@ defineGreedyShorthand('any', 'mock');
 ['get', 'post', 'put', 'delete', 'head', 'patch'].forEach(method => {
 	defineShorthand(method, 'mock', { method });
 	defineShorthand(`${method}Once`, 'once', { method });
-	defineGreedyShorthand(`${method}Any`, method, { method });
+	defineGreedyShorthand(`${method}Any`, method);
+	defineGreedyShorthand(`${method}AnyOnce`, `${method}Once`);
 });
 
 FetchMock.resetBehavior = function() {

--- a/src/lib/set-up-and-tear-down.js
+++ b/src/lib/set-up-and-tear-down.js
@@ -83,11 +83,7 @@ const defineShorthand = (methodName, underlyingMethod, shorthandOptions) => {
 
 const defineGreedyShorthand = (methodName, underlyingMethod) => {
 	FetchMock[methodName] = function(response, options) {
-		return this[underlyingMethod](
-			{},
-			response,
-			options
-		);
+		return this[underlyingMethod]({}, response, options);
 	};
 };
 

--- a/src/lib/set-up-and-tear-down.js
+++ b/src/lib/set-up-and-tear-down.js
@@ -89,6 +89,7 @@ const defineGreedyShorthand = (methodName, underlyingMethod) => {
 
 defineShorthand('once', 'mock', { repeat: 1 });
 defineGreedyShorthand('any', 'mock');
+defineGreedyShorthand('anyOnce', 'once');
 
 ['get', 'post', 'put', 'delete', 'head', 'patch'].forEach(method => {
 	defineShorthand(method, 'mock', { method });

--- a/src/lib/set-up-and-tear-down.js
+++ b/src/lib/set-up-and-tear-down.js
@@ -80,7 +80,19 @@ const defineShorthand = (methodName, underlyingMethod, shorthandOptions) => {
 		);
 	};
 };
+
+const defineGreedyShorthand = (methodName, underlyingMethod) => {
+	FetchMock[methodName] = function(response, options) {
+		return this[underlyingMethod](
+			{},
+			response,
+			Object.assign(options || {}, shorthandOptions)
+		);
+	};
+};
+
 defineShorthand('once', 'mock', { repeat: 1 });
+defineGreedyShorthand('any', 'mock');
 
 ['get', 'post', 'put', 'delete', 'head', 'patch'].forEach(method => {
 	defineShorthand(method, 'mock', { method });

--- a/src/lib/set-up-and-tear-down.js
+++ b/src/lib/set-up-and-tear-down.js
@@ -86,7 +86,7 @@ const defineGreedyShorthand = (methodName, underlyingMethod) => {
 		return this[underlyingMethod](
 			{},
 			response,
-			Object.assign(options || {}, shorthandOptions)
+			options
 		);
 	};
 };

--- a/test/runner.js
+++ b/test/runner.js
@@ -11,5 +11,6 @@ module.exports = (fetchMock, theGlobal, fetch, AbortController) => {
 		require('./specs/custom-implementations.test')(fetchMock);
 		require('./specs/options.test')(fetchMock, theGlobal, fetch);
 		require('./specs/abortable.test')(fetchMock, AbortController);
+		require('./specs/shorthands.test')(fetchMock);
 	});
 };

--- a/test/specs/repeat.test.js
+++ b/test/specs/repeat.test.js
@@ -226,7 +226,5 @@ module.exports = fetchMock => {
 				expect(sb.done(matcher2)).to.be.true;
 			});
 		});
-
-
 	});
 };

--- a/test/specs/repeat.test.js
+++ b/test/specs/repeat.test.js
@@ -227,62 +227,6 @@ module.exports = fetchMock => {
 			});
 		});
 
-		describe('strict matching shorthands', () => {
-			it('has once shorthand method', () => {
-				sinon.spy(fm, 'compileRoute');
-				fm['once']('a', 'b');
-				fm['once']('c', 'd', { opt: 'e' });
-				expect(
-					fm.compileRoute.calledWith([
-						'a',
-						'b',
-						{
-							repeat: 1
-						}
-					])
-				).to.be.true;
-				expect(
-					fm.compileRoute.calledWith([
-						'c',
-						'd',
-						{
-							opt: 'e',
-							repeat: 1
-						}
-					])
-				).to.be.true;
-				fm.compileRoute.restore();
-			});
 
-			'get,post,put,delete,head,patch'.split(',').forEach(method => {
-				it(`has once shorthand for ${method.toUpperCase()}`, () => {
-					sinon.spy(fm, 'compileRoute');
-					fm[method + 'Once']('a', 'b');
-					fm[method + 'Once']('c', 'd', { opt: 'e' });
-					expect(
-						fm.compileRoute.calledWith([
-							'a',
-							'b',
-							{
-								method: method,
-								repeat: 1
-							}
-						])
-					).to.be.true;
-					expect(
-						fm.compileRoute.calledWith([
-							'c',
-							'd',
-							{
-								opt: 'e',
-								method: method,
-								repeat: 1
-							}
-						])
-					).to.be.true;
-					fm.compileRoute.restore();
-				});
-			});
-		});
 	});
 };

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -545,18 +545,6 @@ module.exports = fetchMock => {
 					expect(fm.calls(true).length).to.equal(1);
 				});
 
-				['get', 'post', 'put', 'delete', 'head', 'patch'].forEach(method => {
-					it(`have shorthand method for ${method}`, async () => {
-						fm[method]('http://it.at.there/', 200).catch();
-
-						await fm.fetchHandler('http://it.at.there/', {
-							method: 'bad-method'
-						});
-						expect(fm.calls(true).length).to.equal(0);
-						await fm.fetchHandler('http://it.at.there/', { method });
-						expect(fm.calls(true).length).to.equal(1);
-					});
-				});
 			});
 
 			describe('body matching', () => {

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -544,7 +544,6 @@ module.exports = fetchMock => {
 					await fm.fetchHandler('http://domain.com/person', { method: 'POST' });
 					expect(fm.calls(true).length).to.equal(1);
 				});
-
 			});
 
 			describe('body matching', () => {

--- a/test/specs/set-up-and-tear-down.test.js
+++ b/test/specs/set-up-and-tear-down.test.js
@@ -109,38 +109,6 @@ module.exports = fetchMock => {
 			});
 		});
 
-		describe('method shorthands', () => {
-			'get,post,put,delete,head,patch'.split(',').forEach(method => {
-				testChainableMethod(() => fm, method, [/a/, 200]);
-
-				it(`has shorthand for ${method.toUpperCase()}`, () => {
-					sinon.spy(fm, 'compileRoute');
-					fm[method]('a', 'b');
-					fm[method]('c', 'd', { opt: 'e' });
-					expect(fm.compileRoute).calledWith([
-						'a',
-						'b',
-						{
-							method: method
-						}
-					]);
-					expect(fm.compileRoute).calledWith([
-						'c',
-						'd',
-						{
-							opt: 'e',
-							method: method
-						}
-					]);
-					fm.compileRoute.restore();
-					fm.restore();
-				});
-
-				testChainableMethod(() => fm, `${method}Once`, [/a/, 200]);
-
-				// tests for behaviour of 'once' shorthands are in repeat.test.js
-			});
-		});
 
 		describe('reset', () => {
 			testChainableMethod(() => fm, 'reset');

--- a/test/specs/set-up-and-tear-down.test.js
+++ b/test/specs/set-up-and-tear-down.test.js
@@ -109,7 +109,6 @@ module.exports = fetchMock => {
 			});
 		});
 
-
 		describe('reset', () => {
 			testChainableMethod(() => fm, 'reset');
 

--- a/test/specs/shorthands.test.js
+++ b/test/specs/shorthands.test.js
@@ -54,7 +54,7 @@ module.exports = fetchMock => {
 			});
 
 
-			it.only('has any() shorthand method', () => {
+			it('has any() shorthand method', () => {
 				sinon.spy(fm, 'compileRoute');
 				fm.any('a', { opt: 'b' });
 				expect(
@@ -70,7 +70,13 @@ module.exports = fetchMock => {
 			});
 
 		describe('method shorthands', () => {
-			'get,post,put,delete,head,patch'.split(',').forEach(method => {
+			['get',
+			// 'post',
+			// 'put',
+			// 'delete',
+			// 'head',
+			// 'patch'
+			].forEach(method => {
 				describe(method.toUpperCase(), () => {
 
 				it(`has ${method}() shorthand`, () => {
@@ -128,6 +134,24 @@ module.exports = fetchMock => {
 
 
 				testChainableMethod(() => fm, `${method}Once`, [/a/, 200]);
+
+				it(`has ${method}Any() shorthand`, () => {
+					sinon.spy(fm, 'compileRoute');
+					fm[method + 'Any']('a', { opt: 'b' });
+					expect(
+						fm.compileRoute.calledWith([
+							{},
+							'a',
+							{
+								opt: 'b',
+								method: method,
+							}
+						])
+					).to.be.true;
+					fm.compileRoute.restore();
+				});
+
+				testChainableMethod(() => fm, `${method}Any`, [200]);
 				})
 			});
 		});

--- a/test/specs/shorthands.test.js
+++ b/test/specs/shorthands.test.js
@@ -27,10 +27,10 @@ module.exports = fetchMock => {
 		});
 		afterEach(() => fm.restore());
 
-			it('has once shorthand method', () => {
+			it('has once() shorthand method', () => {
 				sinon.spy(fm, 'compileRoute');
-				fm['once']('a', 'b');
-				fm['once']('c', 'd', { opt: 'e' });
+				fm.once('a', 'b');
+				fm.once('c', 'd', { opt: 'e' });
 				expect(
 					fm.compileRoute.calledWith([
 						'a',
@@ -54,12 +54,31 @@ module.exports = fetchMock => {
 			});
 
 
+			it.only('has any() shorthand method', () => {
+				sinon.spy(fm, 'compileRoute');
+				fm.any('a');
+				fm.any('c', { opt: 'e' });
+				expect(
+					fm.compileRoute.calledWith([
+						{},
+						'b'
+					])
+				).to.be.true;
+				expect(
+					fm.compileRoute.calledWith([
+						{},
+						'd',
+						{
+							opt: 'e',
+						}
+					])
+				).to.be.true;
+				fm.compileRoute.restore();
+			});
+
 		describe('method shorthands', () => {
 			'get,post,put,delete,head,patch'.split(',').forEach(method => {
 				describe(method.toUpperCase(), () => {
-
-
-
 
 				it(`has ${method}() shorthand`, () => {
 					sinon.spy(fm, 'compileRoute');
@@ -85,8 +104,6 @@ module.exports = fetchMock => {
 				});
 
 				testChainableMethod(() => fm, method, [/a/, 200]);
-
-
 
 				it(`has ${method}Once() shorthand`, () => {
 					sinon.spy(fm, 'compileRoute');

--- a/test/specs/shorthands.test.js
+++ b/test/specs/shorthands.test.js
@@ -1,0 +1,128 @@
+const chai = require('chai');
+chai.use(require('sinon-chai'));
+const expect = chai.expect;
+const sinon = require('sinon');
+
+
+const testChainableMethod = (getFetchMock, method, args = []) => {
+	it(`${method}() is chainable`, () => {
+		expect(getFetchMock()[method](...args)).to.equal(getFetchMock());
+	});
+
+	it(`${method}() has "this"`, () => {
+		sinon.spy(getFetchMock(), method);
+		getFetchMock()[method](...args);
+		expect(getFetchMock()[method].lastCall.thisValue).to.equal(getFetchMock());
+		getFetchMock()[method].restore();
+	});
+};
+
+
+module.exports = fetchMock => {
+	describe('shorthands', () => {
+				let fm;
+		before(() => {
+			fm = fetchMock.createInstance();
+			fm.config.warnOnUnmatched = false;
+		});
+		afterEach(() => fm.restore());
+
+			it('has once shorthand method', () => {
+				sinon.spy(fm, 'compileRoute');
+				fm['once']('a', 'b');
+				fm['once']('c', 'd', { opt: 'e' });
+				expect(
+					fm.compileRoute.calledWith([
+						'a',
+						'b',
+						{
+							repeat: 1
+						}
+					])
+				).to.be.true;
+				expect(
+					fm.compileRoute.calledWith([
+						'c',
+						'd',
+						{
+							opt: 'e',
+							repeat: 1
+						}
+					])
+				).to.be.true;
+				fm.compileRoute.restore();
+			});
+
+
+		describe('method shorthands', () => {
+			'get,post,put,delete,head,patch'.split(',').forEach(method => {
+				describe(method.toUpperCase(), () => {
+
+
+
+
+				it(`has ${method}() shorthand`, () => {
+					sinon.spy(fm, 'compileRoute');
+					fm[method]('a', 'b');
+					fm[method]('c', 'd', { opt: 'e' });
+					expect(fm.compileRoute).calledWith([
+						'a',
+						'b',
+						{
+							method: method
+						}
+					]);
+					expect(fm.compileRoute).calledWith([
+						'c',
+						'd',
+						{
+							opt: 'e',
+							method: method
+						}
+					]);
+					fm.compileRoute.restore();
+					fm.restore();
+				});
+
+				testChainableMethod(() => fm, method, [/a/, 200]);
+
+
+
+				it(`has ${method}Once() shorthand`, () => {
+					sinon.spy(fm, 'compileRoute');
+					fm[method + 'Once']('a', 'b');
+					fm[method + 'Once']('c', 'd', { opt: 'e' });
+					expect(
+						fm.compileRoute.calledWith([
+							'a',
+							'b',
+							{
+								method: method,
+								repeat: 1
+							}
+						])
+					).to.be.true;
+					expect(
+						fm.compileRoute.calledWith([
+							'c',
+							'd',
+							{
+								opt: 'e',
+								method: method,
+								repeat: 1
+							}
+						])
+					).to.be.true;
+					fm.compileRoute.restore();
+				});
+
+
+				testChainableMethod(() => fm, `${method}Once`, [/a/, 200]);
+				})
+			});
+		});
+
+
+
+	})
+}

--- a/test/specs/shorthands.test.js
+++ b/test/specs/shorthands.test.js
@@ -19,160 +19,97 @@ const testChainableMethod = (getFetchMock, method, args = []) => {
 module.exports = fetchMock => {
 	describe('shorthands', () => {
 		let fm;
+		let expectRoute;
 		before(() => {
 			fm = fetchMock.createInstance();
+			sinon.spy(fm, 'compileRoute');
 			fm.config.warnOnUnmatched = false;
+			expectRoute = (...args) => expect(fm.compileRoute).calledWith(args);
 		});
-		afterEach(() => fm.restore());
+		afterEach(() => {
+			fm.compileRoute.resetHistory();
+			fm.restore();
+		});
+
+		after(() => fm.compileRoute.restore());
 
 		it('has once() shorthand method', () => {
-			sinon.spy(fm, 'compileRoute');
 			fm.once('a', 'b');
 			fm.once('c', 'd', { opt: 'e' });
-			expect(
-				fm.compileRoute.calledWith([
-					'a',
-					'b',
-					{
-						repeat: 1
-					}
-				])
-			).to.be.true;
-			expect(
-				fm.compileRoute.calledWith([
-					'c',
-					'd',
-					{
-						opt: 'e',
-						repeat: 1
-					}
-				])
-			).to.be.true;
-			fm.compileRoute.restore();
+			expectRoute('a', 'b', {
+				repeat: 1
+			});
+			expectRoute('c', 'd', {
+				opt: 'e',
+				repeat: 1
+			});
 		});
 
 		it('has any() shorthand method', () => {
-			sinon.spy(fm, 'compileRoute');
 			fm.any('a', { opt: 'b' });
-			expect(
-				fm.compileRoute.calledWith([
-					{},
-					'a',
-					{
-						opt: 'b'
-					}
-				])
-			).to.be.true;
-			fm.compileRoute.restore();
+			expectRoute({}, 'a', {
+				opt: 'b'
+			});
 		});
 
 		it('has anyOnce() shorthand method', () => {
-			sinon.spy(fm, 'compileRoute');
 			fm.anyOnce('a', { opt: 'b' });
-			expect(
-				fm.compileRoute.calledWith([
-					{},
-					'a',
-					{
-						opt: 'b',
-						repeat: 1
-					}
-				])
-			).to.be.true;
-			fm.compileRoute.restore();
+			expectRoute({}, 'a', {
+				opt: 'b',
+				repeat: 1
+			});
 		});
 
 		describe('method shorthands', () => {
 			['get', 'post', 'put', 'delete', 'head', 'patch'].forEach(method => {
 				describe(method.toUpperCase(), () => {
 					it(`has ${method}() shorthand`, () => {
-						sinon.spy(fm, 'compileRoute');
 						fm[method]('a', 'b');
 						fm[method]('c', 'd', { opt: 'e' });
-						expect(fm.compileRoute).calledWith([
-							'a',
-							'b',
-							{
-								method: method
-							}
-						]);
-						expect(fm.compileRoute).calledWith([
-							'c',
-							'd',
-							{
-								opt: 'e',
-								method: method
-							}
-						]);
-						fm.compileRoute.restore();
-						fm.restore();
+						expectRoute('a', 'b', {
+							method: method
+						});
+						expectRoute('c', 'd', {
+							opt: 'e',
+							method: method
+						});
 					});
 
 					testChainableMethod(() => fm, method, [/a/, 200]);
 
 					it(`has ${method}Once() shorthand`, () => {
-						sinon.spy(fm, 'compileRoute');
 						fm[method + 'Once']('a', 'b');
 						fm[method + 'Once']('c', 'd', { opt: 'e' });
-						expect(
-							fm.compileRoute.calledWith([
-								'a',
-								'b',
-								{
-									method: method,
-									repeat: 1
-								}
-							])
-						).to.be.true;
-						expect(
-							fm.compileRoute.calledWith([
-								'c',
-								'd',
-								{
-									opt: 'e',
-									method: method,
-									repeat: 1
-								}
-							])
-						).to.be.true;
-						fm.compileRoute.restore();
+						expectRoute('a', 'b', {
+							method: method,
+							repeat: 1
+						});
+						expectRoute('c', 'd', {
+							opt: 'e',
+							method: method,
+							repeat: 1
+						});
 					});
 
 					testChainableMethod(() => fm, `${method}Once`, [/a/, 200]);
 
 					it(`has ${method}Any() shorthand`, () => {
-						sinon.spy(fm, 'compileRoute');
 						fm[method + 'Any']('a', { opt: 'b' });
-						expect(
-							fm.compileRoute.calledWith([
-								{},
-								'a',
-								{
-									opt: 'b',
-									method: method
-								}
-							])
-						).to.be.true;
-						fm.compileRoute.restore();
+						expectRoute({}, 'a', {
+							opt: 'b',
+							method: method
+						});
 					});
 
 					testChainableMethod(() => fm, `${method}Any`, [200]);
 
 					it(`has ${method}AnyOnce() shorthand`, () => {
-						sinon.spy(fm, 'compileRoute');
 						fm[method + 'AnyOnce']('a', { opt: 'b' });
-						expect(
-							fm.compileRoute.calledWith([
-								{},
-								'a',
-								{
-									opt: 'b',
-									method: method,
-									repeat: 1
-								}
-							])
-						).to.be.true;
-						fm.compileRoute.restore();
+						expectRoute({}, 'a', {
+							opt: 'b',
+							method: method,
+							repeat: 1
+						});
 					});
 
 					testChainableMethod(() => fm, `${method}Any`, [200]);

--- a/test/specs/shorthands.test.js
+++ b/test/specs/shorthands.test.js
@@ -56,20 +56,13 @@ module.exports = fetchMock => {
 
 			it.only('has any() shorthand method', () => {
 				sinon.spy(fm, 'compileRoute');
-				fm.any('a');
-				fm.any('c', { opt: 'e' });
+				fm.any('a', { opt: 'b' });
 				expect(
 					fm.compileRoute.calledWith([
 						{},
-						'b'
-					])
-				).to.be.true;
-				expect(
-					fm.compileRoute.calledWith([
-						{},
-						'd',
+						'a',
 						{
-							opt: 'e',
+							opt: 'b',
 						}
 					])
 				).to.be.true;

--- a/test/specs/shorthands.test.js
+++ b/test/specs/shorthands.test.js
@@ -152,6 +152,25 @@ module.exports = fetchMock => {
 				});
 
 				testChainableMethod(() => fm, `${method}Any`, [200]);
+
+				it(`has ${method}AnyOnce() shorthand`, () => {
+					sinon.spy(fm, 'compileRoute');
+					fm[method + 'AnyOnce']('a', { opt: 'b' });
+					expect(
+						fm.compileRoute.calledWith([
+							{},
+							'a',
+							{
+								opt: 'b',
+								method: method,
+								repeat: 1
+							}
+						])
+					).to.be.true;
+					fm.compileRoute.restore();
+				});
+
+				testChainableMethod(() => fm, `${method}Any`, [200]);
 				})
 			});
 		});

--- a/test/specs/shorthands.test.js
+++ b/test/specs/shorthands.test.js
@@ -3,7 +3,6 @@ chai.use(require('sinon-chai'));
 const expect = chai.expect;
 const sinon = require('sinon');
 
-
 const testChainableMethod = (getFetchMock, method, args = []) => {
 	it(`${method}() is chainable`, () => {
 		expect(getFetchMock()[method](...args)).to.equal(getFetchMock());
@@ -17,165 +16,152 @@ const testChainableMethod = (getFetchMock, method, args = []) => {
 	});
 };
 
-
 module.exports = fetchMock => {
 	describe('shorthands', () => {
-				let fm;
+		let fm;
 		before(() => {
 			fm = fetchMock.createInstance();
 			fm.config.warnOnUnmatched = false;
 		});
 		afterEach(() => fm.restore());
 
-			it('has once() shorthand method', () => {
-				sinon.spy(fm, 'compileRoute');
-				fm.once('a', 'b');
-				fm.once('c', 'd', { opt: 'e' });
-				expect(
-					fm.compileRoute.calledWith([
-						'a',
-						'b',
-						{
-							repeat: 1
-						}
-					])
-				).to.be.true;
-				expect(
-					fm.compileRoute.calledWith([
-						'c',
-						'd',
-						{
-							opt: 'e',
-							repeat: 1
-						}
-					])
-				).to.be.true;
-				fm.compileRoute.restore();
-			});
+		it('has once() shorthand method', () => {
+			sinon.spy(fm, 'compileRoute');
+			fm.once('a', 'b');
+			fm.once('c', 'd', { opt: 'e' });
+			expect(
+				fm.compileRoute.calledWith([
+					'a',
+					'b',
+					{
+						repeat: 1
+					}
+				])
+			).to.be.true;
+			expect(
+				fm.compileRoute.calledWith([
+					'c',
+					'd',
+					{
+						opt: 'e',
+						repeat: 1
+					}
+				])
+			).to.be.true;
+			fm.compileRoute.restore();
+		});
 
-
-			it('has any() shorthand method', () => {
-				sinon.spy(fm, 'compileRoute');
-				fm.any('a', { opt: 'b' });
-				expect(
-					fm.compileRoute.calledWith([
-						{},
-						'a',
-						{
-							opt: 'b',
-						}
-					])
-				).to.be.true;
-				fm.compileRoute.restore();
-			});
+		it('has any() shorthand method', () => {
+			sinon.spy(fm, 'compileRoute');
+			fm.any('a', { opt: 'b' });
+			expect(
+				fm.compileRoute.calledWith([
+					{},
+					'a',
+					{
+						opt: 'b'
+					}
+				])
+			).to.be.true;
+			fm.compileRoute.restore();
+		});
 
 		describe('method shorthands', () => {
-			['get',
-			// 'post',
-			// 'put',
-			// 'delete',
-			// 'head',
-			// 'patch'
-			].forEach(method => {
+			['get', 'post', 'put', 'delete', 'head', 'patch'].forEach(method => {
 				describe(method.toUpperCase(), () => {
-
-				it(`has ${method}() shorthand`, () => {
-					sinon.spy(fm, 'compileRoute');
-					fm[method]('a', 'b');
-					fm[method]('c', 'd', { opt: 'e' });
-					expect(fm.compileRoute).calledWith([
-						'a',
-						'b',
-						{
-							method: method
-						}
-					]);
-					expect(fm.compileRoute).calledWith([
-						'c',
-						'd',
-						{
-							opt: 'e',
-							method: method
-						}
-					]);
-					fm.compileRoute.restore();
-					fm.restore();
-				});
-
-				testChainableMethod(() => fm, method, [/a/, 200]);
-
-				it(`has ${method}Once() shorthand`, () => {
-					sinon.spy(fm, 'compileRoute');
-					fm[method + 'Once']('a', 'b');
-					fm[method + 'Once']('c', 'd', { opt: 'e' });
-					expect(
-						fm.compileRoute.calledWith([
+					it(`has ${method}() shorthand`, () => {
+						sinon.spy(fm, 'compileRoute');
+						fm[method]('a', 'b');
+						fm[method]('c', 'd', { opt: 'e' });
+						expect(fm.compileRoute).calledWith([
 							'a',
 							'b',
 							{
-								method: method,
-								repeat: 1
+								method: method
 							}
-						])
-					).to.be.true;
-					expect(
-						fm.compileRoute.calledWith([
+						]);
+						expect(fm.compileRoute).calledWith([
 							'c',
 							'd',
 							{
 								opt: 'e',
-								method: method,
-								repeat: 1
+								method: method
 							}
-						])
-					).to.be.true;
-					fm.compileRoute.restore();
+						]);
+						fm.compileRoute.restore();
+						fm.restore();
+					});
+
+					testChainableMethod(() => fm, method, [/a/, 200]);
+
+					it(`has ${method}Once() shorthand`, () => {
+						sinon.spy(fm, 'compileRoute');
+						fm[method + 'Once']('a', 'b');
+						fm[method + 'Once']('c', 'd', { opt: 'e' });
+						expect(
+							fm.compileRoute.calledWith([
+								'a',
+								'b',
+								{
+									method: method,
+									repeat: 1
+								}
+							])
+						).to.be.true;
+						expect(
+							fm.compileRoute.calledWith([
+								'c',
+								'd',
+								{
+									opt: 'e',
+									method: method,
+									repeat: 1
+								}
+							])
+						).to.be.true;
+						fm.compileRoute.restore();
+					});
+
+					testChainableMethod(() => fm, `${method}Once`, [/a/, 200]);
+
+					it(`has ${method}Any() shorthand`, () => {
+						sinon.spy(fm, 'compileRoute');
+						fm[method + 'Any']('a', { opt: 'b' });
+						expect(
+							fm.compileRoute.calledWith([
+								{},
+								'a',
+								{
+									opt: 'b',
+									method: method
+								}
+							])
+						).to.be.true;
+						fm.compileRoute.restore();
+					});
+
+					testChainableMethod(() => fm, `${method}Any`, [200]);
+
+					it(`has ${method}AnyOnce() shorthand`, () => {
+						sinon.spy(fm, 'compileRoute');
+						fm[method + 'AnyOnce']('a', { opt: 'b' });
+						expect(
+							fm.compileRoute.calledWith([
+								{},
+								'a',
+								{
+									opt: 'b',
+									method: method,
+									repeat: 1
+								}
+							])
+						).to.be.true;
+						fm.compileRoute.restore();
+					});
+
+					testChainableMethod(() => fm, `${method}Any`, [200]);
 				});
-
-
-				testChainableMethod(() => fm, `${method}Once`, [/a/, 200]);
-
-				it(`has ${method}Any() shorthand`, () => {
-					sinon.spy(fm, 'compileRoute');
-					fm[method + 'Any']('a', { opt: 'b' });
-					expect(
-						fm.compileRoute.calledWith([
-							{},
-							'a',
-							{
-								opt: 'b',
-								method: method,
-							}
-						])
-					).to.be.true;
-					fm.compileRoute.restore();
-				});
-
-				testChainableMethod(() => fm, `${method}Any`, [200]);
-
-				it(`has ${method}AnyOnce() shorthand`, () => {
-					sinon.spy(fm, 'compileRoute');
-					fm[method + 'AnyOnce']('a', { opt: 'b' });
-					expect(
-						fm.compileRoute.calledWith([
-							{},
-							'a',
-							{
-								opt: 'b',
-								method: method,
-								repeat: 1
-							}
-						])
-					).to.be.true;
-					fm.compileRoute.restore();
-				});
-
-				testChainableMethod(() => fm, `${method}Any`, [200]);
-				})
 			});
 		});
-
-
-
-	})
-}
+	});
+};

--- a/test/specs/shorthands.test.js
+++ b/test/specs/shorthands.test.js
@@ -66,6 +66,22 @@ module.exports = fetchMock => {
 			fm.compileRoute.restore();
 		});
 
+		it('has anyOnce() shorthand method', () => {
+			sinon.spy(fm, 'compileRoute');
+			fm.anyOnce('a', { opt: 'b' });
+			expect(
+				fm.compileRoute.calledWith([
+					{},
+					'a',
+					{
+						opt: 'b',
+						repeat: 1
+					}
+				])
+			).to.be.true;
+			fm.compileRoute.restore();
+		});
+
 		describe('method shorthands', () => {
 			['get', 'post', 'put', 'delete', 'head', 'patch'].forEach(method => {
 				describe(method.toUpperCase(), () => {


### PR DESCRIPTION
Adds numerous shortcut methods to make generating a mock response for any fetch call a bit easier - no need to learn the matching syntax.

Part of me thinks developers shouldn't be doing this, as it makes the tests less reliable, but I can see how it might be convenient to do this sometimes - we're already mocking out the http layer so assuming the API still obeys its contract; adding this any feature effectively means we trust the layer that creates the http request to construct it correctly so that a request for the expected data is made correctly, which is perhaps reasonable in more complex client side applications.