### PR TITLE
feat: mock node-fetch's export pattern

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -55,11 +55,17 @@ FetchMock.sandbox = function() {
 	const sandbox = Object.assign(
 		proxy, // Ensures that the entire returned object is a callable function
 		FetchMock, // prototype methods
-		this.createInstance() // instance data
+		this.createInstance(), // instance data
+		{
+			Headers: this.config.Headers,
+			Request: this.config.Request,
+			Response: this.config.Response
+		}
 	);
 
 	sandbox.bindMethods();
 	sandbox.isSandbox = true;
+	sandbox.default = sandbox;
 	return sandbox;
 };
 

--- a/test/specs/sandbox.test.js
+++ b/test/specs/sandbox.test.js
@@ -144,5 +144,20 @@ module.exports = (fetchMock, theGlobal) => {
 			fm.config.fetch = originalFetch;
 			expect(() => fm.spy()).not.to.throw();
 		});
+
+		it('exports a properly mocked node-fetch module shape', () => {
+			// uses node-fetch default require pattern
+			const {
+				default: fetch,
+				Headers,
+				Request,
+				Response
+			} = fetchMock.sandbox();
+
+			expect(fetch.name).to.equal('proxy');
+			expect(new Headers()).to.be.an.instanceOf(fetchMock.config.Headers);
+			expect(new Request()).to.be.an.instanceOf(fetchMock.config.Request);
+			expect(new Response()).to.be.an.instanceOf(fetchMock.config.Response);
+		});
 	});
 };


### PR DESCRIPTION
Resolves wheresrhys/fetch-mock#528

Modified `FetchMock`'s `sandbox` method to return an interface that more closely mocks `node-fetch`'s export pattern. This prevents code that relies on `node-fetch` from breaking during testing in some situations. Everything is done in the sandbox, so users that modify the main class config with their own implementations can still take advantage of the re-exposed `Headers`, `Request`, and `Response` classes if they so desire. 

Created test verifying the new return value.