### PR TITLE
Allow query matcher to use repeated query string parameters

### DIFF
--- a/docs/_api-mocking/mock_matcher.md
+++ b/docs/_api-mocking/mock_matcher.md
@@ -146,7 +146,7 @@ parameters:
         types:
           - Object
         content: |-
-          Match only requests that have these query parameters set (in any order)
+          Match only requests that have these query parameters set (in any order). In order to match keys which are used multiple times use an array of strings.
         examples:
           - |-
             {"q": "cute+kittenz", "format": "gif"}

--- a/docs/_api-mocking/mock_matcher.md
+++ b/docs/_api-mocking/mock_matcher.md
@@ -150,6 +150,8 @@ parameters:
         examples:
           - |-
             {"q": "cute+kittenz", "format": "gif"}
+          - |-
+            {"tags": ["cute", "kittenz"]}
       - name: params
         types:
           - Object

--- a/src/lib/matchers.js
+++ b/src/lib/matchers.js
@@ -87,13 +87,15 @@ const getQueryStringMatcher = ({ query: expectedQuery }) => {
 		debug('  Actual query parameters:', query);
 		return keys.every((key) => {
 			const value = query[key];
-			const expectedValue = query[key];
+			const expectedValue = expectedQuery[key];
 			if (Array.isArray(value) && Array.isArray(expectedValue)) {
-				return value.every(q => expectedValue.includes(q)) &&
-					expectedValue.every(q => value.includes(q));
+				return (
+					value.every((q) => expectedValue.includes(q)) &&
+					expectedValue.every((q) => value.includes(q))
+				);
 			}
-                        return real === expected;
-               });
+			return value === expectedValue;
+		});
 	};
 };
 

--- a/src/lib/matchers.js
+++ b/src/lib/matchers.js
@@ -86,15 +86,11 @@ const getQueryStringMatcher = ({ query: expectedQuery }) => {
 		debug('  Expected query parameters:', expectedQuery);
 		debug('  Actual query parameters:', query);
 		return keys.every((key) => {
-			const value = query[key];
-			const expectedValue = expectedQuery[key];
-			if (Array.isArray(value) && Array.isArray(expectedValue)) {
-				return (
-					value.every((q) => expectedValue.includes(q)) &&
-					expectedValue.every((q) => value.includes(q))
-				);
-			}
-			return value === expectedValue;
+			const value = Array.isArray(query[key]) ? query[key] : [query[key]];
+			const expectedValue = Array.isArray(expectedQuery[key])
+				? expectedQuery[key]
+				: [expectedQuery[key]];
+			return isEqual(value.sort(), expectedValue.sort());
 		});
 	};
 };

--- a/src/lib/matchers.js
+++ b/src/lib/matchers.js
@@ -85,7 +85,15 @@ const getQueryStringMatcher = ({ query: expectedQuery }) => {
 		const query = querystring.parse(getQuery(url));
 		debug('  Expected query parameters:', expectedQuery);
 		debug('  Actual query parameters:', query);
-		return keys.every((key) => query[key] === expectedQuery[key]);
+		return keys.every((key) => {
+			const value = query[key];
+			const expectedValue = query[key];
+			if (Array.isArray(value) && Array.isArray(expectedValue)) {
+				return value.every(q => expectedValue.includes(q)) &&
+					expectedValue.every(q => value.includes(q));
+			}
+                        return real === expected;
+               });
 	};
 };
 

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -450,6 +450,20 @@ module.exports = (fetchMock) => {
 					expect(fm.calls(true).length).to.equal(2);
 				});
 
+				it('can match a query string array of length 1', async () => {
+					fm.mock(
+						{ url: 'http://it.at.there/', query: { a: ['b'] } },
+						200
+					).catch();
+
+					await fm.fetchHandler('http://it.at.there');
+					expect(fm.calls(true).length).to.equal(0);
+					await fm.fetchHandler('http://it.at.there?a=b');
+					expect(fm.calls(true).length).to.equal(1);
+					await fm.fetchHandler('http://it.at.there?a=b&a=c');
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
 				it('can be used alongside existing query strings', async () => {
 					fm.mock('http://it.at.there/?c=d', 200, {
 						query: { a: 'b' },

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -432,6 +432,24 @@ module.exports = (fetchMock) => {
 					expect(fm.calls(true).length).to.equal(2);
 				});
 
+				it('can match repeated query strings', async () => {
+					fm.mock(
+						{ url: 'http://it.at.there/', query: { a: ['b', 'c'] } },
+						200
+					).catch();
+
+					await fm.fetchHandler('http://it.at.there');
+					expect(fm.calls(true).length).to.equal(0);
+					await fm.fetchHandler('http://it.at.there?a=b');
+					expect(fm.calls(true).length).to.equal(0);
+					await fm.fetchHandler('http://it.at.there?a=b&a=c');
+					expect(fm.calls(true).length).to.equal(1);
+					await fm.fetchHandler('http://it.at.there?a=c&a=b');
+					expect(fm.calls(true).length).to.equal(2);
+					await fm.fetchHandler('http://it.at.there?a=b&a=c&a=d');
+					expect(fm.calls(true).length).to.equal(2);
+				});
+
 				it('can be used alongside existing query strings', async () => {
 					fm.mock('http://it.at.there/?c=d', 200, {
 						query: { a: 'b' },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -157,7 +157,7 @@ declare namespace fetchMock {
         /**
          * key/value map of query strings to match, in any order
          */
-        query?: { [key: string]: string };
+        query?: { [key: string]: string | string[] };
 
         /**
          * key/value map of express style path params to match


### PR DESCRIPTION
Pretty self explanatory PR.

```
fetchMock.mock({
  query: {
    a: ["b", "c"]
  }
}....
```
which will match:
http://my.domain.url/api?a=b&a=c

But not
http://my.domain.url/api?a=b
http://my.domain.url/api?a=b&a=c&a=d