### PR TITLE
fix: request with query params not containing string values not validated correctly

### DIFF
--- a/docs/_api-mocking/mock_matcher.md
+++ b/docs/_api-mocking/mock_matcher.md
@@ -166,10 +166,10 @@ parameters:
         types:
           - Object
         content: |-
-          Match only requests that have these query parameters set (in any order)
+          Match only requests that have these query parameters set (in any order). Query parameters are matched by using Node.js [querystring](https://nodejs.org/api/querystring.html) module. If it doesn't fulfil your requirements, you should append query parameters to the url manually.
         examples:
           - |-
-            {"q": "cute+kittenz", "format": "gif"}
+            {"q": "cute+kittenz", "format": "gif", inform: true}
       - name: params
         versionAdded: 6.0.0
         types:

--- a/src/lib/compile-route.js
+++ b/src/lib/compile-route.js
@@ -1,3 +1,5 @@
+const querystring = require('querystring');
+
 const { debug, setDebugNamespace, getDebug } = require('./debug');
 
 const isUrlMatcher = (matcher) =>
@@ -42,6 +44,10 @@ const sanitizeRoute = (route) => {
 	}
 
 	route.functionMatcher = route.matcher || route.functionMatcher;
+
+	if(route.query && route.url){
+		route.url += '?' + querystring.stringify(route.query)
+	}
 
 	debug('Setting route.identifier...');
 	debug(`  route.name is ${route.name}`);

--- a/src/lib/compile-route.js
+++ b/src/lib/compile-route.js
@@ -45,10 +45,6 @@ const sanitizeRoute = (route) => {
 
 	route.functionMatcher = route.matcher || route.functionMatcher;
 
-	if(route.query && route.url){
-		route.url += '?' + querystring.stringify(route.query)
-	}
-
 	debug('Setting route.identifier...');
 	debug(`  route.name is ${route.name}`);
 	debug(`  route.url is ${route.url}`);

--- a/src/lib/compile-route.js
+++ b/src/lib/compile-route.js
@@ -1,5 +1,3 @@
-const querystring = require('querystring');
-
 const { debug, setDebugNamespace, getDebug } = require('./debug');
 
 const isUrlMatcher = (matcher) =>

--- a/src/lib/matchers.js
+++ b/src/lib/matchers.js
@@ -86,7 +86,18 @@ const getQueryStringMatcher = ({ query: passedQuery }) => {
 		const query = querystring.parse(getQuery(url));
 		debug('  Expected query parameters:', expectedQuery);
 		debug('  Actual query parameters:', query);
-		return keys.every((key) => query[key] === expectedQuery[key]);
+		return keys.every((key) => {
+			if(Array.isArray(query[key])){
+				if(!Array.isArray(expectedQuery[key])){
+					return false
+				}else{
+					// Not the recommend way of checking but it would cover all cases
+					// because both of the values are gone through querystring module
+					return query[key].sort().toString() === expectedQuery[key].sort().toString()
+				}
+			}
+			return query[key] === expectedQuery[key]
+		});
 	};
 };
 

--- a/src/lib/matchers.js
+++ b/src/lib/matchers.js
@@ -80,7 +80,7 @@ const getQueryStringMatcher = ({ query: passedQuery }) => {
 	}
 	const expectedQuery = querystring.parse(querystring.stringify(passedQuery))
 	debug('  Expected query parameters:', passedQuery);
-	const keys = Object.keys(passedQuery);
+	const keys = Object.keys(expectedQuery);
 	return (url) => {
 		debug('Attempting to match query parameters');
 		const query = querystring.parse(getQuery(url));

--- a/src/lib/matchers.js
+++ b/src/lib/matchers.js
@@ -91,9 +91,7 @@ const getQueryStringMatcher = ({ query: passedQuery }) => {
 				if(!Array.isArray(expectedQuery[key])){
 					return false
 				}else{
-					// Not the recommend way of checking but it would cover all cases
-					// because both of the values are gone through querystring module
-					return query[key].sort().toString() === expectedQuery[key].sort().toString()
+					return isEqual(query[key].sort(), expectedQuery[key].sort())
 				}
 			}
 			return query[key] === expectedQuery[key]

--- a/src/lib/matchers.js
+++ b/src/lib/matchers.js
@@ -72,14 +72,15 @@ const getMethodMatcher = ({ method: expectedMethod }) => {
 	};
 };
 
-const getQueryStringMatcher = ({ query: expectedQuery }) => {
+const getQueryStringMatcher = ({ query: passedQuery }) => {
 	debug('Generating query parameters matcher');
-	if (!expectedQuery) {
+	if (!passedQuery) {
 		debug('  No query parameters expectations defined - skipping');
 		return;
 	}
-	debug('  Expected query parameters:', expectedQuery);
-	const keys = Object.keys(expectedQuery);
+	const expectedQuery = querystring.parse(querystring.stringify(passedQuery))
+	debug('  Expected query parameters:', passedQuery);
+	const keys = Object.keys(passedQuery);
 	return (url) => {
 		debug('Attempting to match query parameters');
 		const query = querystring.parse(getQuery(url));

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -376,21 +376,25 @@ module.exports = (fetchMock) => {
 			describe('query strings', () => {
 				it('can match a query string', async () => {
 					fm.mock('http://it.at.there/', 200, {
-						query: { a: 'b' },
+						query: { a: 'b', b: 2 },
 					}).catch();
 
 					await fm.fetchHandler('http://it.at.there');
 					expect(fm.calls(true).length).to.equal(0);
-					await fm.fetchHandler('http://it.at.there?a=b');
+					await fm.fetchHandler('http://it.at.there?a=b&b=2');
 					expect(fm.calls(true).length).to.equal(1);
 				});
 
 				it('match a query string against an URL object', async () => {
 					fm.mock('http://it.at.there/path', 200, {
-						query: { a: 'b' },
+						query: {
+							a: 'b',
+							b: 1
+						},
 					}).catch();
 					const url = new URL.URL('http://it.at.there/path');
 					url.searchParams.append('a', 'b');
+					url.searchParams.append('b', '1');
 					await fm.fetchHandler(url);
 					expect(fm.calls(true).length).to.equal(1);
 				});

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -1,3 +1,5 @@
+const querystring = require('querystring');
+
 const chai = require('chai');
 const URL = require('whatwg-url');
 const expect = chai.expect;
@@ -477,6 +479,21 @@ module.exports = (fetchMock) => {
 					await fm.fetchHandler('http://it.at.there');
 					expect(fm.calls(true).length).to.equal(0);
 					await fm.fetchHandler('http://it.at.there?baz=2&baz=1');
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
+				it('can match a query string with different value types', async () => {
+					const query = { bool: true, num: 1, arr: [1, 2], nested: { key: ["val1", "val2"] }, nullish: null, und: undefined }
+					fm.mock( 'http://it.at.there/', 200, {
+						query
+					}).catch();
+
+					await fm.fetchHandler('http://it.at.there');
+					expect(fm.calls(true).length).to.equal(0);
+
+					const qs = querystring.stringify(query)
+
+					await fm.fetchHandler('http://it.at.there?'+ qs);
 					expect(fm.calls(true).length).to.equal(1);
 				});
 

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -456,6 +456,30 @@ module.exports = (fetchMock) => {
 					await fm.fetchHandler('http://domain.com/person?a=b');
 					expect(fm.calls(true).length).to.equal(1);
 				});
+
+				it('can match a query string with different value types', async () => {
+					fm.mock('http://it.at.there/', 200, {
+						query: { foo: 'bar', baz: ['qux', 'quux'], corge: '' }
+					}).catch();
+
+					await fm.fetchHandler('http://it.at.there');
+					expect(fm.calls(true).length).to.equal(0);
+					await fm.fetchHandler('http://it.at.there?foo=bar&baz=qux&baz=quux&corge=');
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
+
+				it('can match a query string with different ordered array value types', async () => {
+					fm.mock( 'http://it.at.there/', 200, {
+						query: { baz: ['1', '2'] }
+					}).catch();
+
+					await fm.fetchHandler('http://it.at.there');
+					expect(fm.calls(true).length).to.equal(0);
+					await fm.fetchHandler('http://it.at.there?baz=2&baz=1');
+					expect(fm.calls(true).length).to.equal(1);
+				});
+
 			});
 
 			describe('path parameters', () => {

--- a/test/specs/routing.test.js
+++ b/test/specs/routing.test.js
@@ -387,10 +387,7 @@ module.exports = (fetchMock) => {
 
 				it('match a query string against an URL object', async () => {
 					fm.mock('http://it.at.there/path', 200, {
-						query: {
-							a: 'b',
-							b: 1
-						},
+						query: { a: 'b', b: 1 },
 					}).catch();
 					const url = new URL.URL('http://it.at.there/path');
 					url.searchParams.append('a', 'b');

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -157,7 +157,7 @@ declare namespace fetchMock {
         /**
          * key/value map of query strings to match, in any order
          */
-        query?: { [key: string]: string | number | (string|number)[] };
+        query?: object;
 
         /**
          * key/value map of express style path params to match

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -157,7 +157,7 @@ declare namespace fetchMock {
         /**
          * key/value map of query strings to match, in any order
          */
-        query?: { [key: string]: string };
+        query?: { [key: string]: string | number | (string|number)[] };
 
         /**
          * key/value map of express style path params to match


### PR DESCRIPTION
Given the example: 
```js
const mocker = fetchMock.sandbox()

const params = {
   a: 1,
   b: 2
}

const request = mocker.mock({
  url: 'http://test.example.com',
  method: 'GET',
  query: params
}, 200);

fetch( {
   url : 'http://test.example.com?'+ qs.stringify(params),
   method: 'GET'
}).then( () => {
   assert request.called() === true   // fails
})
```

The problem is query matcher checks for passed query values without transforming them. For ex. if the passed query param is a number it will fail because received query params will be string. 