### PR TITLE
calrify query behaviour

### DIFF
--- a/docs/_api-mocking/mock_matcher.md
+++ b/docs/_api-mocking/mock_matcher.md
@@ -170,10 +170,11 @@ parameters:
           - strings, numbers and booleans are coerced to strings
           - arrays of values are coerced to repetitions of the key
           - all other values, including `undefined`, are coerced to an empty string
-          The request will be matched whichever order keys appear in the query string
+          The request will be matched whichever order keys appear in the query string. 
+          Any query parameters sent in the request which are not included in the keys of the object provided will be ignored.
         examples:
           - |-
-            {"q": "cute+kittenz"} // matches '?q=cute kittenz' or ?q=cute+kittenz'
+            {"q": "cute+kittenz"} // matches '?q=cute kittenz' or ?q=cute+kittenz' or ?q=cute+kittenz&mode=big'
           - |-
             {"tags": ["cute", "kittenz"]} // matches `?q=cute&q=kittenz`
           - |-

--- a/test/specs/routing/query-string-matching.test.js
+++ b/test/specs/routing/query-string-matching.test.js
@@ -70,6 +70,18 @@ describe('query string matching', () => {
 		expect(fm.calls(true).length).to.equal(2);
 	});
 
+	it('ignore irrelevant query strings', async () => {
+		fm.mock(
+			{
+				query: { a: 'b', c: 'd' },
+			},
+			200
+		).catch();
+
+		await fm.fetchHandler('http://a.com?a=b&c=d&e=f');
+		expect(fm.calls(true).length).to.equal(1);
+	});
+
 	it('match an empty query string', async () => {
 		fm.mock(
 			{


### PR DESCRIPTION
add test and clarify docs on how unspecified query strings affect matching
