### PR TITLE
Clone response so body is consumable in call log

### DIFF
--- a/src/lib/fetch-handler.js
+++ b/src/lib/fetch-handler.js
@@ -229,7 +229,7 @@ FetchMock.generateResponse = async function ({
 		route,
 	});
 
-	callLog.response = finalResponse;
+	callLog.response = finalResponse.clone();
 
 	return finalResponse;
 };

--- a/src/lib/fetch-handler.js
+++ b/src/lib/fetch-handler.js
@@ -217,7 +217,7 @@ FetchMock.generateResponse = async function ({
 	// If the response is a pre-made Response, respond with it
 	if (this.config.Response.prototype.isPrototypeOf(response)) {
 		debug('response is already a Response instance - returning it');
-		callLog.response = response;
+		callLog.response = response.clone();
 		return response;
 	}
 

--- a/src/lib/fetch-handler.js
+++ b/src/lib/fetch-handler.js
@@ -222,14 +222,14 @@ FetchMock.generateResponse = async function ({
 	}
 
 	// finally, if we need to convert config into a response, we do it
-	const finalResponse = responseBuilder({
+	const [realResponse, finalResponse] = responseBuilder({
 		url,
 		responseConfig: response,
 		fetchMock: this,
 		route,
 	});
 
-	callLog.response = finalResponse.clone();
+	callLog.response = realResponse.clone();
 
 	return finalResponse;
 };

--- a/src/lib/response-builder.js
+++ b/src/lib/response-builder.js
@@ -170,6 +170,12 @@ e.g. {"body": {"status: "registered"}}`);
 				}
 
 				if (typeof originalResponse[name] === 'function') {
+					if (name === 'clone') {
+						return () => {
+							return originalResponse.clone();
+						};
+					}
+
 					this.debug('Wrapping body promises in ES proxies for observability');
 					return new Proxy(originalResponse[name], {
 						apply: (func, thisArg, args) => {

--- a/src/lib/response-builder.js
+++ b/src/lib/response-builder.js
@@ -19,9 +19,13 @@ class ResponseBuilder {
 		this.normalizeResponseConfig();
 		this.constructFetchOpts();
 		this.constructResponseBody();
-		return this.buildObservableResponse(
-			new this.fetchMock.config.Response(this.body, this.options)
+
+		const realResponse = new this.fetchMock.config.Response(
+			this.body,
+			this.options
 		);
+		const proxyResponse = this.buildObservableResponse(realResponse);
+		return [realResponse, proxyResponse];
 	}
 
 	sendAsObject() {
@@ -170,12 +174,6 @@ e.g. {"body": {"status: "registered"}}`);
 				}
 
 				if (typeof originalResponse[name] === 'function') {
-					if (name === 'clone') {
-						return () => {
-							return originalResponse.clone();
-						};
-					}
-
 					this.debug('Wrapping body promises in ES proxies for observability');
 					return new Proxy(originalResponse[name], {
 						apply: (func, thisArg, args) => {

--- a/test/specs/config/constructors.test.js
+++ b/test/specs/config/constructors.test.js
@@ -118,7 +118,10 @@ describe('custom implementations', () => {
 		});
 
 		it('should use the configured Response', async () => {
-			const spiedReplacementResponse = sinon.stub().returns({ isFake: true });
+			const obj = { isFake: true };
+			/** Clone from Response interface is used internally to store copy in call log */
+			obj.clone = () => obj;
+			const spiedReplacementResponse = sinon.stub().returns(obj);
 			fm.config.Response = spiedReplacementResponse;
 
 			fm.mock('*', 'hello');

--- a/test/specs/inspecting.test.js
+++ b/test/specs/inspecting.test.js
@@ -518,5 +518,16 @@ describe('inspecting', () => {
 			expect(fm.lastResponse().status).to.equal(201);
 			fm.restore();
 		});
+		it('has readable response', async () => {
+			const respBody = {foo: 'bar'}
+			fm.once('*', {status: 200, body: respBody}).once('*', 201, {
+				overwriteRoutes: false,
+			});
+
+			const resp = await fm.fetchHandler('http://a.com/');
+
+			await resp.json()
+			expect(await fm.calls()[0].response.json()).to.eql(respBody)
+		});
 	});
 });

--- a/test/specs/inspecting.test.js
+++ b/test/specs/inspecting.test.js
@@ -519,15 +519,15 @@ describe('inspecting', () => {
 			fm.restore();
 		});
 		it('has readable response', async () => {
-			const respBody = {foo: 'bar'}
-			fm.once('*', {status: 200, body: respBody}).once('*', 201, {
+			const respBody = { foo: 'bar' };
+			fm.once('*', { status: 200, body: respBody }).once('*', 201, {
 				overwriteRoutes: false,
 			});
 
 			const resp = await fm.fetchHandler('http://a.com/');
 
-			await resp.json()
-			expect(await fm.calls()[0].response.json()).to.eql(respBody)
+			await resp.json();
+			expect(await fm.calls()[0].response.json()).to.eql(respBody);
 		});
 	});
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -231,6 +231,7 @@ declare namespace fetchMock {
         identifier: string;
         isUnmatched: boolean | undefined;
         request: Request | undefined;
+        response: Response | undefined;
     }
 
     interface MockOptionsMethodGet extends MockOptions {


### PR DESCRIPTION
fixes #573 

Clones real responses so that the body is consumable from the call log.

This is particularly handy when `spy()`ing on an API for inspection or later replay..