### PR TITLE
Enable typescript on esm build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ build: transpile
 	cp -r src/* cjs
 	rollup -c rollup.config.js
 	echo '{"type": "module"}' > esm/package.json
+	cp types/index.d.ts esm/client.d.ts
+	cp types/index.d.ts esm/server.d.ts
 
 docs:
 	cd docs; jekyll serve build --watch

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -662,3 +662,8 @@ declare namespace fetchMock {
 
 declare var fetchMock: fetchMock.FetchMockStatic;
 export = fetchMock;
+
+declare module 'fetch-mock/esm/client' {
+  const fetchMock: fetchMock.FetchMockStatic;
+  export default fetchMock;
+}


### PR DESCRIPTION
A PR to enable typing on `import fetchMock from 'fetch-mock/esm/client';`

And thx for your component!