### PR TITLE
Patch native fetch on Safari to fix #584

### DIFF
--- a/src/lib/fetch-handler.js
+++ b/src/lib/fetch-handler.js
@@ -18,6 +18,50 @@ class AbortError extends Error {
 	}
 }
 
+// Patch native fetch to avoid "NotSupportedError:ReadableStream uploading is not supported" in Safari.
+// See also https://github.com/wheresrhys/fetch-mock/issues/584
+// See also https://stackoverflow.com/a/50952018/1273406
+const patchNativeFetchForSafari = (nativeFetch) => {
+	// Try to patch fetch only on Safari
+	if (
+		!navigator ||
+		!navigator.vendor ||
+		navigator.vendor !== 'Apple Computer, Inc.'
+	) {
+		return nativeFetch;
+	}
+	// It seems the code is working on Safari thus patch native fetch to avoid the error.
+	return async (request) => {
+		const { method } = request;
+		if (!['POST', 'PUT', 'PATCH'].includes(method)) {
+			// No patch is required in this case
+			return nativeFetch(request);
+		}
+		const body = await request.clone().text();
+		const {
+			cache,
+			credentials,
+			headers,
+			integrity,
+			mode,
+			redirect,
+			referrer,
+		} = request;
+		const init = {
+			body,
+			cache,
+			credentials,
+			headers,
+			integrity,
+			mode,
+			redirect,
+			referrer,
+			method,
+		};
+		return nativeFetch(request.url, init);
+	};
+};
+
 const resolve = async (
 	{ response, responseIsFetch = false },
 	url,
@@ -252,7 +296,7 @@ FetchMock.getNativeFetch = function () {
 			'fetch-mock: Falling back to network only available on global fetch-mock, or by setting config.fetch on sandboxed fetch-mock'
 		);
 	}
-	return func;
+	return patchNativeFetchForSafari(func);
 };
 
 FetchMock.recordCall = function (obj) {


### PR DESCRIPTION
To solve #584, patch native fetch by procedure explained in https://stackoverflow.com/a/50952018/1273406

It's quite ugly but works...

Confirmed with https://github.com/lambdalisue/fetch-mock-test by using patched fetch-mock.