### PR TITLE
Fix: support overwriting routes with regex matcher

### DIFF
--- a/src/lib/set-up-and-tear-down.js
+++ b/src/lib/set-up-and-tear-down.js
@@ -13,11 +13,13 @@ FetchMock.mock = function (...args) {
 FetchMock.addRoute = function (uncompiledRoute) {
 	debug('Adding route', uncompiledRoute);
 	const route = this.compileRoute(uncompiledRoute);
-	const clashes = this.routes.filter(
-		({ identifier, method }) =>
-			identifier === route.identifier &&
-			(!method || !route.method || method === route.method)
-	);
+	const clashes = this.routes.filter(({ identifier, method }) => {
+		const isMatch =
+			typeof identifier === 'function'
+				? identifier === route.identifier
+				: String(identifier) === String(route.identifier);
+		return isMatch && (!method || !route.method || method === route.method);
+	});
 
 	if (this.getOption('overwriteRoutes', route) === false || !clashes.length) {
 		this._uncompiledRoutes.push(uncompiledRoute);

--- a/test/specs/config/overwriteRoutes.test.js
+++ b/test/specs/config/overwriteRoutes.test.js
@@ -24,6 +24,14 @@ describe('overwriteRoutes', () => {
 		expect(res.status).to.equal(300);
 	});
 
+	it('allow overwriting existing route, regex matcher', async () => {
+		fm.config.overwriteRoutes = true;
+		expect(() => fm.mock(/a\.com/, 200).mock(/a\.com/, 300)).not.to.throw();
+
+		const res = await fm.fetchHandler('http://a.com');
+		expect(res.status).to.equal(300);
+	});
+
 	it('allow adding additional routes with same matcher', async () => {
 		fm.config.overwriteRoutes = false;
 		expect(() =>


### PR DESCRIPTION
I came across this issue while trying to mock an existing route using regex matchers.

Prior to this change, using a regex matcher combined with `overwriteRoutes: true` would not overwrite the route. This is because the inspection was comparing regexes with `===` which will always return `false`. To fix this, object identifiers are coerced to strings before comparing. Function matchers are not affected by this change.

As a side note, if you agree with this change and accept this PR, would you mind adding the `hacktoberfest-accepted` label?
