### PR TITLE
Fix/protocol relative urls

### DIFF
--- a/src/lib/request-utils.js
+++ b/src/lib/request-utils.js
@@ -1,7 +1,8 @@
 let URL;
 // https://stackoverflow.com/a/19709846/308237
-// modified, URL constructor does not support protocol-relative urls
+// split, URL constructor does not support protocol-relative urls
 const absoluteUrlRX = new RegExp('^[a-z]+://', 'i');
+const protocolRelativeUrlRX = new RegExp('^//', 'i');
 
 const headersToArray = (headers) => {
 	// node-fetch 1 Headers
@@ -27,6 +28,9 @@ const normalizeUrl = (url) => {
 	}
 	if (absoluteUrlRX.test(url)) {
 		const u = new URL(url);
+		return u.href;
+	} else if (protocolRelativeUrlRX.test(url)) {
+		const u = new URL(url, 'http://dummy');
 		return u.href;
 	} else {
 		const u = new URL(url, 'http://dummy');

--- a/src/lib/request-utils.js
+++ b/src/lib/request-utils.js
@@ -1,6 +1,7 @@
 let URL;
 // https://stackoverflow.com/a/19709846/308237
-const absoluteUrlRX = new RegExp('^(?:[a-z]+:)?//', 'i');
+// modified, URL constructor does not support protocol-relative urls
+const absoluteUrlRX = new RegExp('^[a-z]+://', 'i');
 
 const headersToArray = (headers) => {
 	// node-fetch 1 Headers

--- a/test/specs/routing/url-matching.test.js
+++ b/test/specs/routing/url-matching.test.js
@@ -20,10 +20,8 @@ describe('url matching', () => {
 		await fm.fetchHandler('http://a.co/path');
 		expect(fm.calls(true).length).to.equal(0);
 		await fm.fetchHandler('http://a.com/path');
-		expect(fm.calls(true).length).to.equal(1);
-		// gets normalized to http://a.com/path
 		await fm.fetchHandler('//a.com/path');
-		expect(fm.calls(true).length).to.equal(1);
+		expect(fm.calls(true).length).to.equal(2);
 	});
 
 	it('match exact strings with relative url', async () => {

--- a/test/specs/routing/url-matching.test.js
+++ b/test/specs/routing/url-matching.test.js
@@ -21,6 +21,9 @@ describe('url matching', () => {
 		expect(fm.calls(true).length).to.equal(0);
 		await fm.fetchHandler('http://a.com/path');
 		expect(fm.calls(true).length).to.equal(1);
+		// gets normalized to http://a.com/path
+		await fm.fetchHandler('//a.com/path');
+		expect(fm.calls(true).length).to.equal(1);
 	});
 
 	it('match exact strings with relative url', async () => {
@@ -127,6 +130,12 @@ describe('url matching', () => {
 			await fm.fetchHandler('http://b.com/');
 			await fm.fetchHandler('http://b.com');
 			expect(fm.calls(true).length).to.equal(4);
+		});
+		it('match protocol-relative urls with catch-all', async () => {
+			fm.any(200).catch();
+
+			await fm.fetchHandler('//a.com/path');
+			expect(fm.calls(true).length).to.equal(1);
 		});
 	});
 });


### PR DESCRIPTION
Hi @wheresrhys, thank you for your amazing work with this library.

I found a problem while mocking calls from a client library that works in the browser and sends protocol-relative requests.

I was trying the simplest mock possible with the `any()` shortcut, and it was throwing an error like this:

![image](https://user-images.githubusercontent.com/482075/97024795-7e494080-1557-11eb-85f7-389d2a2f4c29.png)

Seems that the `URL()` constructor does not accept protocol-relative URLs without a base, like `'http://dummy'` (at least in Chrome) so I split the regex in two to handle that case by setting the same dummy base as for the last case in the code, but returning the href as in the original case.

The relevant code that breaks is here:

https://github.com/wheresrhys/fetch-mock/blob/c553baf8295d2a57ad05b4d7524b866a42a0a9e6/src/lib/request-utils.js#L19-L34

I hope I did it right 😱 