### PR TITLE
Fix types for mock's aliases

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -223,7 +223,7 @@ declare namespace fetchMock {
          * @default true
          */
         includeContentLength?: boolean;
-        
+
         /**
          * Match calls that only partially match a specified body json.
          */
@@ -253,6 +253,10 @@ declare namespace fetchMock {
 
     interface MockOptionsMethodDelete extends MockOptions {
         method?: 'DELETE';
+    }
+
+    interface MockOptionsMethodPatch extends MockOptions {
+        method?: 'PATCH';
     }
 
     interface MockOptionsMethodHead extends MockOptions {
@@ -306,7 +310,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Optional additional properties defining the route to mock
          */
-        once(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptions): this;
+        once(matcher: MockMatcher | MockOptions, response: MockResponse | MockResponseFunction, options?: MockOptions): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -317,7 +321,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Additional properties defining the route to mock
          */
-        get(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodGet): this;
+        get(matcher: MockMatcher | MockOptionsMethodGet, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodGet): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -329,7 +333,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Additional properties defining the route to mock
          */
-        getOnce(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodGet): this;
+        getOnce(matcher: MockMatcher | MockOptionsMethodGet, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodGet): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -340,7 +344,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Additional properties defining the route to mock
          */
-        post(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodPost): this;
+        post(matcher: MockMatcher | MockOptionsMethodPost, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodPost): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -352,7 +356,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Additional properties defining the route to mock
          */
-        postOnce(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodPost): this;
+        postOnce(matcher: MockMatcher | MockOptionsMethodPost, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodPost): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -363,7 +367,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Additional properties defining the route to mock
          */
-        put(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodPut): this;
+        put(matcher: MockMatcher | MockOptionsMethodPut, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodPut): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -375,7 +379,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Additional properties defining the route to mock
          */
-        putOnce(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodPut): this;
+        putOnce(matcher: MockMatcher | MockOptionsMethodPut, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodPut): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -386,7 +390,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Additional properties defining the route to mock
          */
-        delete(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodDelete): this;
+        delete(matcher: MockMatcher | MockOptionsMethodDelete, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodDelete): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -398,7 +402,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Additional properties defining the route to mock
          */
-        deleteOnce(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodDelete): this;
+        deleteOnce(matcher: MockMatcher | MockOptionsMethodDelete, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodDelete): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -409,7 +413,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Additional properties defining the route to mock
          */
-        head(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodHead): this;
+        head(matcher: MockMatcher | MockOptionsMethodHead, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodHead): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -421,7 +425,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Additional properties defining the route to mock
          */
-        headOnce(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodHead): this;
+        headOnce(matcher: MockMatcher | MockOptionsMethodHead, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodHead): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -432,7 +436,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Additional properties defining the route to mock
          */
-        patch(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodHead): this;
+        patch(matcher: MockMatcher | MockOptionsMethodPatch, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodPatch): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -444,7 +448,7 @@ declare namespace fetchMock {
          * @param response Configures the http response returned by the mock
          * @param [options] Additional properties defining the route to mock
          */
-        patchOnce(matcher: MockMatcher, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodHead): this;
+        patchOnce(matcher: MockMatcher | MockOptionsMethodPatch, response: MockResponse | MockResponseFunction, options?: MockOptionsMethodPatch): this;
 
         /**
          * Chainable method that defines how to respond to calls to fetch that
@@ -574,14 +578,14 @@ declare namespace fetchMock {
 
         /**
          * Returns the options for the call to fetch matching the given filter.
-         * This is an experimental feature, very difficult to implement well given 
+         * This is an experimental feature, very difficult to implement well given
          * fetch’s very private treatment of response bodies.
          * When doing all the following:
            -  using node-fetch
            -  responding with a real network response (using spy() or fallbackToNetwork)
            -  using `fetchMock.LastResponse()`
            -  awaiting the body content
-               … the response will hang unless your source code also awaits the response body. 
+               … the response will hang unless your source code also awaits the response body.
                This is an unavoidable consequence of the nodejs implementation of streams.
          * @param [filter] Allows filtering of calls to fetch based on various
          * criteria


### PR DESCRIPTION
All the mocking API functions should also accept an object as an argument in the `matcher` parameter like in the `mock` function.