### PR TITLE
Accept data: URLs

### DIFF
--- a/src/lib/request-utils.js
+++ b/src/lib/request-utils.js
@@ -1,7 +1,7 @@
 let URL;
-// https://stackoverflow.com/a/19709846/308237
+// https://stackoverflow.com/a/19709846/308237 plus data: scheme
 // split, URL constructor does not support protocol-relative urls
-const absoluteUrlRX = new RegExp('^[a-z]+://', 'i');
+const absoluteUrlRX = new RegExp('^[a-z]+://|^data:', 'i');
 const protocolRelativeUrlRX = new RegExp('^//', 'i');
 
 const headersToArray = (headers) => {


### PR DESCRIPTION
Browsers have supported data: URLs in the fetch API for some time now. node-fetch will support them as well in its upcoming v3. The fetch API is the simplest and most reliable way to extract files from data: URLs.

Adding this support precludes a future "data:" matching prefix. This change should not break any existing HTTP(S) matchers, but since the "data:" scheme was previously stripped from URLs passed to matchers, this change will break any existing matchers for data: URLs that were full-string, "begin:", front-anchored regex/glob, or otherwise assumed that the "data:" scheme would be absent.

I did not include support for blob: URLs since they are opaque, less feasible to meaningfully test, and not supported by node-fetch.