### PR TITLE
FIX: Ensure all arguments are passed to base fetch function

### DIFF
--- a/src/lib/fetch-handler.js
+++ b/src/lib/fetch-handler.js
@@ -31,11 +31,11 @@ const patchNativeFetchForSafari = (nativeFetch) => {
 		return nativeFetch;
 	}
 	// It seems the code is working on Safari thus patch native fetch to avoid the error.
-	return async (request) => {
+	return async (request, ...args) => {
 		const { method } = request;
 		if (!['POST', 'PUT', 'PATCH'].includes(method)) {
 			// No patch is required in this case
-			return nativeFetch(request);
+			return nativeFetch(request, ...args);
 		}
 		const body = await request.clone().text();
 		const {

--- a/test/specs/config/safari.test.js
+++ b/test/specs/config/safari.test.js
@@ -1,0 +1,41 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+const { fetchMock, theGlobal } = testGlobals;
+
+describe('Safari override', () => {
+	beforeEach(() => {
+		fetchMock.createInstance();
+	});
+
+	it('passes all GET arguments to next function when not under Safari', async () => {
+		theGlobal.fetch = async (...args) => {
+			expect(args[0]).to.equal('http://mocked.com/');
+			expect(args[1]).to.deep.equal({ method: 'GET' });
+			return { status: 202 };
+		};
+		fetchMock.spy('http://mocked.com');
+		const res = await fetchMock.fetchHandler('http://mocked.com', {
+			method: 'GET',
+		});
+		expect(res.status).to.equal(202);
+		fetchMock.restore();
+		delete theGlobal.fetch;
+	});
+
+	it('passes all GET arguments to next function under Safari', async () => {
+		theGlobal.navigator = { vendor: 'Apple Computer, Inc.' };
+		theGlobal.fetch = async (...args) => {
+			expect(args[0]).to.equal('http://mocked.com/');
+			expect(args[1]).to.deep.equal({ method: 'GET' });
+			return { status: 202 };
+		};
+		fetchMock.spy('http://mocked.com');
+		const res = await fetchMock.fetchHandler('http://mocked.com', {
+			method: 'GET',
+		});
+		expect(res.status).to.equal(202);
+		fetchMock.restore();
+		delete theGlobal.fetch;
+	});
+});


### PR DESCRIPTION
This is not a great fix; it ignores that method is only inspected when it's in the first fetch() parameter, and it glosses over the fact that the navigator object, for historical reasons, is [very constrained in the responses it gives](https://html.spec.whatwg.org/multipage/system-state.html#client-identification) (which is why the code snagged jsdom in the first place).

It does, however, solve my immediate need of getting fetch-mock to interoperate with jsdom.

Fixes wheresrhys/fetch-mock#608