### PR TITLE
Sticky types

### DIFF
--- a/types/fetch-mock-tests.ts
+++ b/types/fetch-mock-tests.ts
@@ -186,6 +186,10 @@ sandbox.get("http://test.com", {
     redirectUrl: "http://example.org"
 });
 
+const stickySandbox = fetchMock.sandbox();
+stickySandbox.sticky("http://test.com", 200);
+stickySandbox.mock("http://test.com", 200, { sticky: true });
+
 const response: fetchMock.MockResponseObject = {
     throws: new Error('error'),
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -228,6 +228,12 @@ declare namespace fetchMock {
          * Match calls that only partially match a specified body json.
          */
         matchPartialBody?: boolean;
+
+        /**
+         * Avoids a route being removed when reset(), restore() or resetBehavior() are called.
+         * Note - this does not preserve the history of calls to the route
+         */
+        sticky?: boolean;
     }
 
     interface MockCall extends Array<string | RequestInit | undefined> {
@@ -300,6 +306,18 @@ declare namespace fetchMock {
          * parallel.
          */
         sandbox(): FetchMockSandbox;
+
+        /**
+         * Replaces fetch() with a stub which records its calls, grouped by
+         * route, and optionally returns a mocked Response object or passes the
+         *  call through to fetch(). Shorthand for mock() which creates a route
+         *  that persists even when restore(), reset() or resetbehavior() are called.
+         *  Calls to .sticky() can be chained.
+         * @param matcher Condition for selecting which requests to mock
+         * @param response Configures the http response returned by the mock
+         * @param [options] Additional properties defining the route to mock
+         */
+        sticky(matcher: MockMatcher | MockOptions, response: MockResponse | MockResponseFunction, options?: MockOptions): this;
 
         /**
          * Replaces fetch() with a stub which records its calls, grouped by
@@ -694,4 +712,4 @@ export = fetchMock;
 declare module 'fetch-mock/esm/client' {
   const fetchMock: fetchMock.FetchMockStatic;
   export default fetchMock;
-}
+} 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -712,4 +712,4 @@ export = fetchMock;
 declare module 'fetch-mock/esm/client' {
   const fetchMock: fetchMock.FetchMockStatic;
   export default fetchMock;
-} 
+}


### PR DESCRIPTION
Added sticky?: boolean type to MockOptions interface
Added sticky() function to FetchMockStatic per http://www.wheresrhys.co.uk/fetch-mock/#api-mockingmock_sticky
Updated fetch-mock-tests.ts to align with the above changes