### PR TITLE
Support exact-matching on FormData bodies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint-config-origami-component": "1.0.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.1",
+    "form-data": "^2.3.3",
     "karma": "^3.1.4",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/src/Route/matchers.js
+++ b/src/Route/matchers.js
@@ -142,7 +142,7 @@ const getBodyMatcher = (route, fetchMock) => {
 			return true;
 		}
 
-		let sentBody;
+		let sentBody = body;
 
 		try {
 			debug('  Parsing request body as JSON');


### PR DESCRIPTION
Hello 👋 

While attempting to mock some client-side calls to `fetch` using `fetch-mock` 9.11.0, I was hoping I'd be able to match `FormData` bodies in addition to JSON. I do see in the [docs]() that it's called out that JSON is supported. Would you be open to a change supporting other kinds of bodies?

The diff as-is will support exact matches of `FormData` (see the included tests; I've also patched this change locally in my repository as a test and validated that it solves my issues there as well). It _also_ will likely support other exact-matches of bodies (e.g. plaintext), but I've not explicitly called out support for that. I'd be happy to do some work to limit it to `FormData` only if you'd like (I'll just need to investigate a little more to make it compatible with both client and server environments).