### PR TITLE
Make global compatible with esmodules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,8 @@ module.exports = {
   },
   "globals": {
     "expect": true,
-    "testGlobals": true
+    "testGlobals": true,
+    "globalThis": true
   },
   "rules": {
     "guard-for-in": 0

--- a/src/client.js
+++ b/src/client.js
@@ -1,6 +1,15 @@
 const FetchMock = require('./lib/index');
 const statusTextMap = require('./lib/status-text');
-const theGlobal = typeof window !== 'undefined' ? window : self;
+const theGlobal =
+	typeof globalThis !== 'undefined'
+		? globalThis
+		: typeof window !== 'undefined'
+		? window
+		: typeof global !== 'undefined'
+		? global
+		: typeof self !== 'undefined'
+		? self
+		: {};
 const { setUrlImplementation } = require('./lib/request-utils');
 setUrlImplementation(theGlobal.URL);
 

--- a/test/specs/config/constructors.test.js
+++ b/test/specs/config/constructors.test.js
@@ -119,7 +119,7 @@ describe('custom implementations', () => {
 
 		it('should use the configured Response', async () => {
 			const obj = { isFake: true };
-			/** Clone from Response interface is used internally to store copy in call log */
+			/* Clone from Response interface is used internally to store copy in call log */
 			obj.clone = () => obj;
 			const spiedReplacementResponse = sinon.stub().returns(obj);
 			fm.config.Response = spiedReplacementResponse;


### PR DESCRIPTION
When importing this package into a `.mjs` file causes a crash where `self` is undefined.

This should fix that issue.