### PR TITLE
allow String objects in normalizeRequest

### DIFF
--- a/src/lib/request-utils.js
+++ b/src/lib/request-utils.js
@@ -80,6 +80,7 @@ module.exports = {
 			return normalizedRequestObject;
 		} else if (
 			typeof url === 'string' ||
+			url instanceof String ||
 			// horrible URL object duck-typing
 			(typeof url === 'object' && 'href' in url)
 		) {


### PR DESCRIPTION
So far, if the url string was represented as instance of `String` class, reqest mock would fail with `Unrecognised Request object`