### PR TITLE
fix: do not require `node-fetch` for Node 18+

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -6,7 +6,7 @@ try {
 	// Hence the try/catch
 	fetch = jest.requireActual('node-fetch'); //eslint-disable-line no-undef
 } catch (e) {
-	fetch = require('node-fetch');
+	fetch = global.fetch || require('node-fetch');
 }
 const Request = fetch.Request;
 const Response = fetch.Response;

--- a/src/server.js
+++ b/src/server.js
@@ -8,9 +8,9 @@ try {
 } catch (e) {
 	fetch = global.fetch || require('node-fetch');
 }
-const Request = fetch.Request;
-const Response = fetch.Response;
-const Headers = fetch.Headers;
+const Request = global.Request || fetch.Request;
+const Response = global.Response || fetch.Response;
+const Headers = global.Headers || fetch.Headers;
 const Stream = require('stream');
 const FetchMock = require('./lib/index');
 const http = require('http');


### PR DESCRIPTION
Node 18 comes with a built-in `fetch` function now. This simple change makes it compatible to use with Node 18, without requiring the install of `node-fetch`