### PR TITLE
types: added global URL type to `MockMatcherUrl`

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,12 +72,12 @@
     "eslint-config-origami-component": "1.0.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.1",
-    "karma": "^3.1.4",
+    "karma": "^6.4.1",
     "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^2.2.0",
-    "karma-mocha": "^1.3.0",
+    "karma-chrome-launcher": "^3.1.1",
+    "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
-    "karma-webpack": "^3.0.0",
+    "karma-webpack": "^5.0.0",
     "mocha": "^7.1.2",
     "node-fetch": "^2.6.0",
     "nyc": "^11.7.3",
@@ -92,6 +92,6 @@
     "sinon": "^4.5.0",
     "sinon-chai": "^2.14.0",
     "typescript": "^3.6.4",
-    "webpack": "^4.41.2"
+    "webpack": "^5.74.0"
   }
 }

--- a/src/lib/fetch-handler.js
+++ b/src/lib/fetch-handler.js
@@ -38,15 +38,8 @@ const patchNativeFetchForSafari = (nativeFetch) => {
 			return nativeFetch(request);
 		}
 		const body = await request.clone().text();
-		const {
-			cache,
-			credentials,
-			headers,
-			integrity,
-			mode,
-			redirect,
-			referrer,
-		} = request;
+		const { cache, credentials, headers, integrity, mode, redirect, referrer } =
+			request;
 		const init = {
 			body,
 			cache,

--- a/src/lib/response-builder.js
+++ b/src/lib/response-builder.js
@@ -86,9 +86,8 @@ e.g. {"body": {"status: "registered"}}`);
 		this.options = this.responseConfig.options || {};
 		this.options.url = this.responseConfig.redirectUrl || this.url;
 		this.options.status = this.validateStatus(this.responseConfig.status);
-		this.options.statusText = this.fetchMock.statusTextMap[
-			String(this.options.status)
-		];
+		this.options.statusText =
+			this.fetchMock.statusTextMap[String(this.options.status)];
 
 		// Set up response headers. The empty object is to cope with
 		// new Headers(undefined) throwing in Chrome
@@ -140,7 +139,8 @@ e.g. {"body": {"status: "registered"}}`);
 		if (this.Stream) {
 			this.debug('Creating response stream');
 			const stream = new this.Stream.Readable();
-			if (this.body != null) { //eslint-disable-line
+			//eslint-disable-next-line
+			if (this.body != null) {
 				stream.push(this.body, 'utf-8');
 			}
 			stream.push(null);

--- a/src/lib/set-up-and-tear-down.js
+++ b/src/lib/set-up-and-tear-down.js
@@ -115,8 +115,10 @@ Wrap in an arrow function instead e.g. \`() => fetchMock.restore()\``);
 	}
 };
 
-const getRouteRemover = ({ sticky: removeStickyRoutes }) => (routes) =>
-	removeStickyRoutes ? [] : routes.filter(({ sticky }) => sticky);
+const getRouteRemover =
+	({ sticky: removeStickyRoutes }) =>
+	(routes) =>
+		removeStickyRoutes ? [] : routes.filter(({ sticky }) => sticky);
 
 FetchMock.resetBehavior = function (options = {}) {
 	mochaAsyncHookWorkaround(options);

--- a/test/specs/inspecting.test.js
+++ b/test/specs/inspecting.test.js
@@ -77,19 +77,27 @@ describe('inspecting', () => {
 
 		const fetchUrls = (...urls) => Promise.all(urls.map(fm.fetchHandler));
 
-		const expectFilteredLength = (...filter) => (length) =>
-			expect(fm.filterCalls(...filter).length).to.equal(length);
+		const expectFilteredLength =
+			(...filter) =>
+			(length) =>
+				expect(fm.filterCalls(...filter).length).to.equal(length);
 
-		const expectFilteredUrl = (...filter) => (url) =>
-			expect(fm.filterCalls(...filter)[0][0]).to.equal(url);
+		const expectFilteredUrl =
+			(...filter) =>
+			(url) =>
+				expect(fm.filterCalls(...filter)[0][0]).to.equal(url);
 
-		const expectSingleUrl = (...filter) => (url) => {
-			expectFilteredLength(...filter)(1);
-			expectFilteredUrl(...filter)(url);
-		};
+		const expectSingleUrl =
+			(...filter) =>
+			(url) => {
+				expectFilteredLength(...filter)(1);
+				expectFilteredUrl(...filter)(url);
+			};
 
-		const expectFilteredResponse = (...filter) => (...response) =>
-			expect(fm.filterCalls(...filter)[0]).to.eql(response);
+		const expectFilteredResponse =
+			(...filter) =>
+			(...response) =>
+				expect(fm.filterCalls(...filter)[0]).to.eql(response);
 
 		it('returns [url, options] pairs', async () => {
 			fm.mock('http://a.com/', 200, { name: 'fetch-mock' });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,7 +27,7 @@ declare namespace fetchMock {
     type MockMatcherFunction = (url: string, opts: MockRequest) => boolean;
 
 
-    type MockMatcherUrl = string | RegExp;
+    type MockMatcherUrl = string | RegExp | URL;
 
 
     /**


### PR DESCRIPTION
In the [docs](https://www.wheresrhys.co.uk/fetch-mock/#api-mockingmock_matcher) the second entry to `Argument values` states that `url` can be any of `String` and `URL`, however the types do not support `URL`.