### PR TITLE
fix: remove usage of querystring

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "glob-to-regexp": "^0.4.0",
     "is-subset": "^0.1.1",
     "lodash.isequal": "^4.5.0",
-    "path-to-regexp": "^2.2.1",
-    "querystring": "^0.2.1"
+    "path-to-regexp": "^2.2.1"
   },
   "peerDependenciesMeta": {
     "node-fetch": {


### PR DESCRIPTION
Related: https://github.com/wheresrhys/fetch-mock/issues/626

This PR rewrites query string matcher using a `URLSearchParams` JS API.

All tests pass.