### PR TITLE
docs: add Int as response parameter type of mock function

### DIFF
--- a/docs/docs/fetch-mock/API/Mocking/mock.md
+++ b/docs/docs/fetch-mock/API/Mocking/mock.md
@@ -22,7 +22,7 @@ Note that if you use matchers that target anything other than the url string, yo
 
 ### response
 
-`{String|Object|Function|Promise|Response}`
+`{String|Int|Object|Function|Promise|Response}`
 
 Response to send when a call is matched
 


### PR DESCRIPTION
[`Int` is an allowed response type for status codes](https://www.wheresrhys.co.uk/fetch-mock/docs/fetch-mock/API/Mocking/Parameters/response/#status-code), but was missing from the mock function documentation.