### PR TITLE
fix: commonjs module import from typescript

### DIFF
--- a/shared-rollup.config.js
+++ b/shared-rollup.config.js
@@ -6,6 +6,7 @@ export default {
 		dir: './dist',
 		entryFileNames: 'commonjs.js',
 		format: 'commonjs',
+		exports: 'named',
 	},
 	plugins: [
 		nodeResolve({ preferBuiltins: false }),


### PR DESCRIPTION
After our discussion #760, I went to update our imports and ran into the following problem:

Because `index.d.ts` has a default export, it seems like typescript decides that `packages/fetch-mock/dist/commonjs.js` should have a default export, but rollup does not create one:
```javascript
var index = FetchMock.createInstance();

module.exports = index;
```

This means that when we call `fetchMock.mock`, typescript turns this into `fetchMock.default.mock` which is undefined. If you want to see this behavior in a little more detail, [here's a repo](https://github.com/brucespang/fetch-mock-760-example) I used to debug it.

Rollup has an option [`output.exports`](https://rollupjs.org/configuration-options/#output-exports) which seems to fix it.