### PR TITLE
fix: roll back to glob-to-regexp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@types/eslint__js": "^8.42.3",
         "@types/events": "^3.0.3",
-        "@types/globrex": "^0.1.4",
         "@types/node": "^20.14.10",
         "@vitest/browser": "^1.1.0",
         "@vitest/coverage-istanbul": "^1.1.0",
@@ -5912,11 +5911,10 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/globrex": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@types/globrex/-/globrex-0.1.4.tgz",
-      "integrity": "sha512-qm82zaOxfn8Us/GGjNrQQ1XfCBUDV86DxQgIQq/p1zGHlt0xnbUiabNjN9rZUhMNvvIE2gg8iTW+GMfw0TnnLg==",
-      "dev": true
+    "node_modules/@types/glob-to-regexp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@types/glob-to-regexp/-/glob-to-regexp-0.4.4.tgz",
+      "integrity": "sha512-nDKoaKJYbnn1MZxUY0cA1bPmmgZbg0cTq7Rh13d0KWYNOiKbqoR+2d89SnRPszGh7ROzSwZ/GOjZ4jPbmmZ6Eg=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -12492,11 +12490,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -25452,8 +25445,9 @@
       "version": "0.4.11",
       "license": "ISC",
       "dependencies": {
+        "@types/glob-to-regexp": "^0.4.4",
         "dequal": "^2.0.3",
-        "globrex": "^0.1.2",
+        "glob-to-regexp": "^0.4.1",
         "is-subset-of": "^3.1.10",
         "regexparam": "^3.0.0"
       }
@@ -25462,8 +25456,9 @@
       "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
+        "@types/glob-to-regexp": "^0.4.4",
         "dequal": "^2.0.3",
-        "globrex": "^0.1.2",
+        "glob-to-regexp": "^0.4.1",
         "is-subset": "^0.1.1",
         "regexparam": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@types/eslint__js": "^8.42.3",
     "@types/events": "^3.0.3",
-    "@types/globrex": "^0.1.4",
     "@types/node": "^20.14.10",
     "@vitest/browser": "^1.1.0",
     "@vitest/coverage-istanbul": "^1.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,8 +32,9 @@
   "homepage": "https://github.com/wheresrhys/fetch-mock#readme",
   "dependencies": {
     "dequal": "^2.0.3",
-    "globrex": "^0.1.2",
+    "glob-to-regexp": "^0.4.1",
     "is-subset-of": "^3.1.10",
-    "regexparam": "^3.0.0"
+    "regexparam": "^3.0.0",
+    "@types/glob-to-regexp": "^0.4.4"
   }
 }

--- a/packages/core/src/Matchers.ts
+++ b/packages/core/src/Matchers.ts
@@ -1,6 +1,6 @@
 import { RouteConfig} from './Route.js';
 import { CallLog } from './CallHistory.js';
-import glob from 'globrex';
+import glob from 'glob-to-regexp';
 import * as regexparam from 'regexparam';
 import { isSubsetOf } from 'is-subset-of';
 import { dequal as isEqual } from 'dequal';
@@ -44,8 +44,8 @@ const stringMatchers: { [key: string]: UrlMatcherGenerator } = {
 			url.substr(-targetString.length) === targetString,
 
 	glob: (targetString) => {
-		const urlRX = /** @type {{regex: RegExp}} */ (glob(targetString));
-		return ({ url }) => urlRX.regex.test(url);
+		const urlRX = glob(targetString);
+		return ({ url }) => urlRX.test(url);
 	},
 	express: (targetString) => {
 		const urlRX = regexparam.parse(targetString);
@@ -56,7 +56,6 @@ const stringMatchers: { [key: string]: UrlMatcherGenerator } = {
 				return false;
 			}
 			vals.shift();
-			/** @type {Object.<string,string>} */
 			callLog.expressParams = urlRX.keys.reduce(
 				(map, paramName, i) =>
 					vals[i] ? Object.assign(map, { [paramName]: vals[i] }) : map,

--- a/packages/fetch-mock/package.json
+++ b/packages/fetch-mock/package.json
@@ -43,7 +43,8 @@
   "homepage": "http://www.wheresrhys.co.uk/fetch-mock",
   "dependencies": {
     "dequal": "^2.0.3",
-    "globrex": "^0.1.2",
+    "glob-to-regexp": "^0.4.1",
+    "@types/glob-to-regexp": "^0.4.4",
     "is-subset": "^0.1.1",
     "regexparam": "^3.0.0"
   },

--- a/packages/fetch-mock/src/Route/matchers.js
+++ b/packages/fetch-mock/src/Route/matchers.js
@@ -1,4 +1,4 @@
-import glob from 'globrex';
+import glob from 'glob-to-regexp';
 import * as regexparam from 'regexparam';
 import isSubset from 'is-subset';
 import { dequal as isEqual } from 'dequal';
@@ -22,7 +22,7 @@ const stringMatchers = {
 		),
 	glob: (targetString) => {
 		const urlRX = glob(targetString);
-		return debuggableUrlFunc((url) => urlRX.regex.test(url));
+		return debuggableUrlFunc((url) => urlRX.test(url));
 	},
 	express: (targetString) => {
 		const urlRX = regexparam.parse(targetString);


### PR DESCRIPTION
This is because globrex depends on process, which does not exist in the browser

fixes #793 