### PR TITLE
fix: handle all types of BodyInit correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ references:
 
   node18: &node18
     docker:
-      - image: cimg/node:18.0
+      - image: cimg/node:18.11
   nodelts: &nodelts
     docker:
       - image: cimg/node:lts

--- a/docs/docs/@fetch-mock/core/configuration.md
+++ b/docs/docs/@fetch-mock/core/configuration.md
@@ -19,7 +19,7 @@ Options marked with a `†` can also be overridden for individual calls to `.moc
 
 `{Boolean}` default: `true`
 
-Sets a `Content-Length` header on each response.
+Sets a `Content-Length` header on each response, with the exception of responses whose body is a `FormData` or `ReadableStream` instance as these are hard/impossible to calculate up front.
 
 ### matchPartialBody
 

--- a/docs/docs/@fetch-mock/core/configuration.md
+++ b/docs/docs/@fetch-mock/core/configuration.md
@@ -15,12 +15,6 @@ fetchMock.config.sendAsJson = false;
 
 Options marked with a `†` can also be overridden for individual calls to `.mock(matcher, response, options)` by setting as properties on the `options` parameter
 
-### sendAsJson<sup>†</sup>
-
-`{Boolean}` default: `true`
-
-Always convert objects passed to `.mock()` to JSON strings before building reponses. Can be useful to set to `false` globally if e.g. dealing with a lot of `ArrayBuffer`s. When `true` the `Content-Type: application/json` header will also be set on each response.
-
 ### includeContentLength<sup>†</sup>
 
 `{Boolean}` default: `true`

--- a/docs/docs/@fetch-mock/core/route/response.md
+++ b/docs/docs/@fetch-mock/core/route/response.md
@@ -32,9 +32,13 @@ If the object _only_ contains properties from among those listed below it is use
 
 ### body
 
-`{String|Object}`
+`{String|Object|BodyInit}`
 
-Set the `Response` body, e.g. `"Server responded ok"`, `{ token: 'abcdef' }`. See the `Object` section of the docs below for behaviour when passed an `Object`.
+Set the `Response` body. This could be
+
+- a string e.g. `"Server responded ok"`, `{ token: 'abcdef' }`.
+- an object literal (see the `Object` section of the docs below).
+- Anything else that satisfies the specification for the [body parameter of new Response()](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response#body). This currently allows instances of Blob, ArrayBuffer, TypedArray, DataView, FormData, ReadableStream, URLSearchParams, and String.
 
 ### status
 
@@ -62,9 +66,15 @@ Forces `fetch` to return a `Promise` rejected with the value of `throws` e.g. `n
 
 ## Object
 
-`{Object|ArrayBuffer|...`
+`{Object}`
 
-If the `sendAsJson` option is set to `true`, any object that does not match the schema for a response config will be converted to a `JSON` string and set as the response `body`. Otherwise, the object will be set as the response `body` (useful for `ArrayBuffer`s etc.)
+Any object literal that does not match the schema for a response config will be converted to a `JSON` string and set as the response `body`.
+
+The `Content-Type: application/json` header will also be set on each response. To send JSON responses that do not set this header (e.g. to mock a poorly configured server) manually convert the object to a string first e.g.
+
+```js
+fetchMock.route('http://a.com', JSON.stringify({ prop: 'value' }));
+```
 
 ## Promise
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12077,6 +12077,15 @@
 				"node": "^12.20 || >= 14.13"
 			}
 		},
+		"node_modules/fetch-blob/node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/fetch-mock": {
 			"resolved": "packages/fetch-mock",
 			"link": true
@@ -25499,15 +25508,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/web-streams-polyfill": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/webdriver": {
 			"version": "8.40.2",
 			"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.40.2.tgz",
@@ -26450,7 +26450,7 @@
 		"packages/vitest": {
 			"name": "@fetch-mock/vitest",
 			"version": "0.1.2",
-			"license": "ISC",
+			"license": "MIT",
 			"dependencies": {
 				"@fetch-mock/core": "^0.6.3"
 			},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
 	"types": "./dist/esm/index.d.ts",
 	"type": "module",
 	"engines": {
-		"node": ">=18.0.0"
+		"node": ">=18.11.0"
 	},
 	"dependencies": {
 		"@types/glob-to-regexp": "^0.4.4",

--- a/packages/core/src/FetchMock.ts
+++ b/packages/core/src/FetchMock.ts
@@ -5,7 +5,6 @@ import CallHistory from './CallHistory.js';
 import * as requestUtils from './RequestUtils.js';
 
 export type FetchMockGlobalConfig = {
-	sendAsJson?: boolean;
 	includeContentLength?: boolean;
 	matchPartialBody?: boolean;
 	allowRelativeUrls?: boolean;
@@ -20,7 +19,6 @@ export type FetchMockConfig = FetchMockGlobalConfig & FetchImplementations;
 
 export const defaultFetchMockConfig: FetchMockConfig = {
 	includeContentLength: true,
-	sendAsJson: true,
 	matchPartialBody: false,
 	Request: globalThis.Request,
 	Response: globalThis.Response,

--- a/packages/core/src/Route.ts
+++ b/packages/core/src/Route.ts
@@ -42,7 +42,7 @@ export type RouteConfig = UserRouteConfig &
 	FetchImplementations &
 	InternalRouteConfig;
 export type RouteResponseConfig = {
-	body?: BodyInit | object | null;
+	body?: BodyInit | object ;
 	status?: number;
 	headers?: {
 		[key: string]: string;
@@ -72,7 +72,7 @@ export type RouteResponse =
 	| RouteResponseFunction;
 export type RouteName = string;
 
-function isBodyInit(body: BodyInit | null | object): body is BodyInit {
+function isBodyInit(body: BodyInit | object): body is BodyInit {
 	return (
 		body instanceof Blob ||
 		body instanceof ArrayBuffer ||
@@ -210,7 +210,7 @@ class Route {
 	constructResponseBody(
 		responseInput: RouteResponseConfig,
 		responseOptions: ResponseInitUsingHeaders,
-	): BodyInit | null {
+	): BodyInit {
 		let body = responseInput.body;
 		const bodyIsBodyInit = isBodyInit(body);
 

--- a/packages/core/src/Route.ts
+++ b/packages/core/src/Route.ts
@@ -194,7 +194,7 @@ class Route {
 	constructResponseBody(
 		responseInput: RouteResponseConfig,
 		responseOptions: ResponseInitUsingHeaders,
-	): string | null {
+	): BodyInit | null {
 		// start to construct the body
 		let body = responseInput.body;
 		// convert to json if we need to
@@ -217,8 +217,25 @@ class Route {
 			}
 			return body;
 		}
-		// @ts-expect-error TODO need to implement handling of non-string bodies properlyy
-		return body || null;
+
+		if (
+			body instanceof Blob ||
+			body instanceof ArrayBuffer ||
+			// checks for TypedArray
+			ArrayBuffer.isView(body) ||
+			body instanceof DataView ||
+			body instanceof FormData ||
+			body instanceof ReadableStream ||
+			body instanceof URLSearchParams ||
+			body instanceof String ||
+			typeof body === 'string'
+		) {
+			return body as BodyInit;
+		}
+		if (!body) {
+			return null;
+		}
+		throw new TypeError('Invalid body provided to construct response');
 	}
 
 	static defineMatcher(matcher: MatcherDefinition) {

--- a/packages/core/src/Route.ts
+++ b/packages/core/src/Route.ts
@@ -42,7 +42,7 @@ export type RouteConfig = UserRouteConfig &
 	FetchImplementations &
 	InternalRouteConfig;
 export type RouteResponseConfig = {
-	body?: BodyInit | object ;
+	body?: BodyInit | object;
 	status?: number;
 	headers?: {
 		[key: string]: string;

--- a/packages/core/src/Route.ts
+++ b/packages/core/src/Route.ts
@@ -83,9 +83,9 @@ function isBodyInit(body: BodyInit | null | object): body is BodyInit {
 		body instanceof ReadableStream ||
 		body instanceof URLSearchParams ||
 		body instanceof String ||
-		typeof body === 'string' || 
+		typeof body === 'string' ||
 		body === null
-	) 
+	);
 }
 
 function sanitizeStatus(status?: number): number {
@@ -216,7 +216,7 @@ class Route {
 
 		if (!bodyIsBodyInit) {
 			if (typeof body === 'undefined') {
-				body = null
+				body = null;
 			} else if (typeof body === 'object') {
 				// convert to json if we need to
 				body = JSON.stringify(body);

--- a/packages/core/src/Route.ts
+++ b/packages/core/src/Route.ts
@@ -217,7 +217,7 @@ class Route {
 		if (!bodyIsBodyInit) {
 			if (typeof body === 'undefined') {
 				body = null
-			} else if (typeof body === 'object' && this.config.sendAsJson) {
+			} else if (typeof body === 'object') {
 				// convert to json if we need to
 				body = JSON.stringify(body);
 				if (!responseOptions.headers.has('Content-Type')) {

--- a/packages/core/src/Route.ts
+++ b/packages/core/src/Route.ts
@@ -228,16 +228,29 @@ class Route {
 			}
 		}
 
-		if (typeof body === 'string') {
-			// add a Content-Length header if we need to
-			if (
-				this.config.includeContentLength &&
-				!responseOptions.headers.has('Content-Length')
+		// add a Content-Length header if we need to
+		if (
+			this.config.includeContentLength &&
+			!responseOptions.headers.has('Content-Length') &&
+			!(body instanceof ReadableStream) &&
+			!(body instanceof FormData)
+		) {
+			let length = 0;
+			if (body instanceof Blob) {
+				length = body.size;
+			} else if (
+				body instanceof ArrayBuffer ||
+				ArrayBuffer.isView(body) ||
+				body instanceof DataView
 			) {
-				responseOptions.headers.set('Content-Length', body.length.toString());
+				length = body.byteLength;
+			} else if (body instanceof URLSearchParams) {
+				length = body.toString().length;
+			} else if (typeof body === 'string' || body instanceof String) {
+				length = body.length;
 			}
+			responseOptions.headers.set('Content-Length', length.toString());
 		}
-
 		return body as BodyInit;
 	}
 

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -273,8 +273,8 @@ export default class Router {
 				if (typeof response[name] === 'function') {
 					//@ts-expect-error TODO probably make use of generics here
 					return new Proxy(response[name], {
-						apply: (matcherFunction, thisArg, args) => {
-							const result = matcherFunction.apply(response, args);
+						apply: (func, thisArg, args) => {
+							const result = func.apply(response, args);
 							if (result.then) {
 								pendingPromises.push(
 									//@ts-expect-error TODO probably make use of generics here

--- a/packages/core/src/__tests__/FetchMock/response-construction.test.js
+++ b/packages/core/src/__tests__/FetchMock/response-construction.test.js
@@ -131,8 +131,8 @@ describe('response construction', () => {
 		}
 
 		it('respond with Blob', async () => {
-			const blobParts = ['<q id="a"><span id="b">hey!</span></q>'];
-			const body = new Blob(blobParts, { type: 'text/html' });
+			const blobParts = ['test value'];
+			const body = new Blob(blobParts);
 			fm.route('*', body);
 			const res = await fm.fetchHandler('http://a.com');
 			expect(res.status).to.equal(200);
@@ -167,30 +167,32 @@ describe('response construction', () => {
 		});
 
 		it('respond with ReadableStream', async () => {
-			const body = ReadableStream.from(['a', 'b']);
+			const body = new Blob(['test value']).stream();
 			fm.route('*', body);
 			const res = await fm.fetchHandler('http://a.com');
 			expect(res.status).to.equal(200);
 			const receivedData = await res.text();
-			console.log(receivedData);
-			expect(receivedData).to.eql(body);
+			expect(receivedData).to.eql('test value');
 		});
 	});
 	it('respond with FormData', async () => {
 		const body = new FormData();
+		body.append('field', 'value');
 		fm.route('*', body);
 		const res = await fm.fetchHandler('http://a.com');
 		expect(res.status).to.equal(200);
-		const receivedData = await res.blob();
+		const receivedData = await res.formData();
+		console.log(receivedData);
 		expect(receivedData).to.eql(body);
 	});
 	it('respond with URLSearchParams', async () => {
 		const body = new URLSearchParams();
+		body.append('field', 'value');
 		fm.route('*', body);
 		const res = await fm.fetchHandler('http://a.com');
 		expect(res.status).to.equal(200);
-		const receivedData = await res.blob();
-		expect(receivedData).to.eql(body);
+		const receivedData = await res.formData();
+		expect(receivedData.get('field')).to.equal('value');
 	});
 
 	it('should set the url property on responses', async () => {

--- a/packages/core/src/__tests__/FetchMock/response-construction.test.js
+++ b/packages/core/src/__tests__/FetchMock/response-construction.test.js
@@ -102,39 +102,6 @@ describe('response construction', () => {
 			const res = await fm.fetchHandler('http://a.com/');
 			expect(res.headers.get('content-type')).toEqual('application/json');
 		});
-
-		describe('sendAsJson option', () => {
-			it('convert object responses to json by default', async () => {
-				fm.route('*', { an: 'object' });
-				const res = await fm.fetchHandler('http://it.at.there');
-				expect(res.headers.get('content-type')).toEqual('application/json');
-			});
-
-			it("don't convert when configured false", async () => {
-				fm.config.sendAsJson = false;
-				fm.route('*', { an: 'object' });
-				const res = await fm.fetchHandler('http://it.at.there');
-				// can't check for existence as the spec says, in the browser, that
-				// a default value should be set
-				expect(res.headers.get('content-type')).not.toEqual('application/json');
-			});
-
-			it('local setting can override to true', async () => {
-				fm.config.sendAsJson = false;
-				fm.route('*', { an: 'object' }, { sendAsJson: true });
-				const res = await fm.fetchHandler('http://it.at.there');
-				expect(res.headers.get('content-type')).toEqual('application/json');
-			});
-
-			it('local setting can override to false', async () => {
-				fm.config.sendAsJson = true;
-				fm.route('*', { an: 'object' }, { sendAsJson: false });
-				const res = await fm.fetchHandler('http://it.at.there');
-				// can't check for existence as the spec says, in the browser, that
-				// a default value should be set
-				expect(res.headers.get('content-type')).not.toEqual('application/json');
-			});
-		});
 	});
 
 	it('respond with a complex response, including headers', async () => {
@@ -153,7 +120,7 @@ describe('response construction', () => {
 
 	if (typeof Buffer !== 'undefined') {
 		it('can respond with a buffer', () => {
-			fm.route(/a/, new Buffer('buffer'), { sendAsJson: false });
+			fm.route(/a/, new Buffer('buffer'));
 			return fm
 				.fetchHandler('http://a.com')
 				.then((res) => res.text())
@@ -165,7 +132,7 @@ describe('response construction', () => {
 
 	it('respond with blob', async () => {
 		const blob = new Blob();
-		fm.route('*', blob, { sendAsJson: false });
+		fm.route('*', blob);
 		const res = await fm.fetchHandler('http://a.com');
 		expect(res.status).to.equal(200);
 		const blobData = await res.blob();

--- a/packages/core/src/__tests__/FetchMock/response-construction.test.js
+++ b/packages/core/src/__tests__/FetchMock/response-construction.test.js
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import fetchMock from '../../FetchMock';
 
-describe('response generation', () => {
+describe('response construction', () => {
 	let fm;
 	beforeEach(() => {
 		fm = fetchMock.createInstance();

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -13,7 +13,7 @@
 	"types": "./types/index.d.ts",
 	"type": "module",
 	"engines": {
-		"node": ">=18.0.0"
+		"node": ">=18.11.0"
 	},
 	"dependencies": {
 		"@fetch-mock/core": "^0.6.3"


### PR DESCRIPTION
TODO
- [x] is sendAsJson even necessary now?
- [x] setting content length
- [x] tests for each type
- [x] friendlier error 
- [x] test for error handling
- [x] docs - new support and also removing sendAsJson
- [x] blog post

fixes #713 