### PR TITLE
docs: fix link to cheatsheet

### DIFF
--- a/packages/fetch-mock/README.md
+++ b/packages/fetch-mock/README.md
@@ -54,7 +54,7 @@ fetch-mock requires the following to run:
 
 ## Documentation and Usage
 
-See the [project website](http://www.wheresrhys.co.uk/fetch-mock/) or [cheatsheet](https://github.com/wheresrhys/fetch-mock/blob/master/docs/cheatsheet.md)
+See the [project website](http://www.wheresrhys.co.uk/fetch-mock/) or [cheatsheet](https://github.com/wheresrhys/fetch-mock/blob/main/docs/docs/fetch-mock/Usage/cheatsheet.md)
 
 If you're using jest as your test runner, consider using [fetch-mock-jest](https://www.npmjs.com/package/fetch-mock-jest), a lightweight, jest-friendly wrapper around fetch-mock.
 

--- a/packages/fetch-mock/README.md
+++ b/packages/fetch-mock/README.md
@@ -14,7 +14,7 @@ Features include:
 
 _New_ If using jest, try the new [fetch-mock-jest](https://www.npmjs.com/package/fetch-mock-jest) wrapper.
 
-_New_ [Cheatsheet](https://github.com/wheresrhys/fetch-mock/blob/master/docs/cheatsheet.md)
+_New_ [Cheatsheet](https://github.com/wheresrhys/fetch-mock/blob/main/docs/docs/fetch-mock/Usage/cheatsheet.md)
 
 ![node version](https://img.shields.io/node/v/fetch-mock.svg?style=flat-square)
 [![licence](https://img.shields.io/npm/l/fetch-mock.svg?style=flat-square)](https://github.com/wheresrhys/fetch-mock/blob/master/LICENSE)


### PR DESCRIPTION
File seems to have moved. It's now at https://github.com/wheresrhys/fetch-mock/blob/main/docs/docs/fetch-mock/Usage/cheatsheet.md