### PR TITLE
fix: use file extension to avoid import errors for vitest and jest wrappers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,6 @@ export default {
 	},
 	moduleNameMapper: {
 		'@fetch-mock/core': '<rootDir>/packages/core/dist/cjs/index.js',
+		'(.+)\\.js': '$1',
 	},
 };

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -3,7 +3,7 @@ import {
 	defaultFetchMockConfig,
 	RemoveRouteOptions,
 } from 'fetch-mock';
-import './jest-extensions';
+import './jest-extensions.js';
 import type { Jest } from '@jest/environment';
 
 type MockResetOptions = {

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -4,7 +4,7 @@ import {
 	defaultFetchMockConfig,
 	RemoveRouteOptions,
 } from 'fetch-mock';
-import './vitest-extensions';
+import './vitest-extensions.js';
 
 type MockResetOptions = {
 	includeSticky: boolean;


### PR DESCRIPTION
fixes #860