### PR TITLE
Fix "Edit this page" links

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -39,7 +39,7 @@ const config = {
 					sidebarPath: './sidebars.js',
 					// Please change this to your repo.
 					// Remove this to remove the "edit this page" links.
-					editUrl: 'https://github.com/wheresrhys/fetch-mock/edit/main',
+					editUrl: 'https://github.com/wheresrhys/fetch-mock/edit/main/docs',
 				},
 				theme: {
 					customCss: './src/css/custom.css',


### PR DESCRIPTION
Already proposed a fix in [this commit](https://github.com/wheresrhys/fetch-mock/commit/649e7e54e8278aa1a142a90a1597827ed4b286ff) but didn't notice that the **docs** folder has a nested **docs** folder