### PR TITLE
fix: adding types to jest matchers

### DIFF
--- a/packages/jest/src/__tests__/extensions.spec.js
+++ b/packages/jest/src/__tests__/extensions.spec.js
@@ -3,16 +3,24 @@ import { describe, it, beforeAll, afterAll, expect } from '@jest/globals';
 import fetchMockModule from '../index';
 const fetchMock = fetchMockModule.default;
 
-describe('expect extensions', () => {
-	[
-		'Fetched',
-		'Got:get',
-		'Posted:post',
-		'Put:put',
-		'Deleted:delete',
-		'FetchedHead:head',
-		'Patched:patch',
-	].forEach((verbs) => {
+const humanVerbToMethods = [
+	'Fetched',
+	'Got:get',
+	'Posted:post',
+	'Put:put',
+	'Deleted:delete',
+	'FetchedHead:head',
+	'Patched:patch',
+];
+
+// initialize a mock here so fetch is patched across all tests
+fetchMock.mockGlobal();
+
+describe.each([
+	['patched fetch input', fetch],
+	['fetchMock input', fetchMock],
+])('expect extensions %s', (_str, expectInput) => {
+	humanVerbToMethods.forEach((verbs) => {
 		const [humanVerb, method] = verbs.split(':');
 		describe(`${humanVerb} expectations`, () => {
 			describe('when no calls', () => {
@@ -21,24 +29,26 @@ describe('expect extensions', () => {
 				});
 				afterAll(() => fetchMock.mockReset());
 				it(`toHave${humanVerb} should be falsy`, () => {
-					expect(fetch).not[`toHave${humanVerb}`]('http://example.com/path');
+					expect(expectInput).not[`toHave${humanVerb}`](
+						'http://example.com/path',
+					);
 				});
 
 				it(`toHaveLast${humanVerb} should be falsy`, () => {
-					expect(fetch).not[`toHaveLast${humanVerb}`](
+					expect(expectInput).not[`toHaveLast${humanVerb}`](
 						'http://example.com/path',
 					);
 				});
 
 				it(`toHaveNth${humanVerb} should be falsy`, () => {
-					expect(fetch).not[`toHaveNth${humanVerb}`](
+					expect(expectInput).not[`toHaveNth${humanVerb}`](
 						1,
 						'http://example.com/path',
 					);
 				});
 
 				it(`toHave${humanVerb}Times should be falsy`, () => {
-					expect(fetch).not[`toHave${humanVerb}Times`](
+					expect(expectInput).not[`toHave${humanVerb}Times`](
 						1,
 						'http://example.com/path',
 					);
@@ -63,15 +73,17 @@ describe('expect extensions', () => {
 				afterAll(() => fetchMock.mockReset());
 
 				it('matches with just url', () => {
-					expect(fetch)[`toHave${humanVerb}`]('http://example.com/path');
+					expect(expectInput)[`toHave${humanVerb}`]('http://example.com/path');
 				});
 
 				it('matches with fetch-mock matcher', () => {
-					expect(fetch)[`toHave${humanVerb}`]('begin:http://example.com/path');
+					expect(expectInput)[`toHave${humanVerb}`](
+						'begin:http://example.com/path',
+					);
 				});
 
 				it('matches with matcher and options', () => {
-					expect(fetch)[`toHave${humanVerb}`]('http://example.com/path', {
+					expect(expectInput)[`toHave${humanVerb}`]('http://example.com/path', {
 						headers: {
 							test: 'header',
 						},
@@ -79,15 +91,18 @@ describe('expect extensions', () => {
 				});
 
 				it("doesn't match if matcher but not options is correct", () => {
-					expect(fetch).not[`toHave${humanVerb}`]('http://example.com/path', {
-						headers: {
-							test: 'not-header',
+					expect(expectInput).not[`toHave${humanVerb}`](
+						'http://example.com/path',
+						{
+							headers: {
+								test: 'not-header',
+							},
 						},
-					});
+					);
 				});
 
 				it("doesn't match if options but not matcher is correct", () => {
-					expect(fetch).not[`toHave${humanVerb}`](
+					expect(expectInput).not[`toHave${humanVerb}`](
 						'http://example-no.com/path',
 						{
 							headers: {
@@ -110,25 +125,30 @@ describe('expect extensions', () => {
 				afterAll(() => fetchMock.mockReset());
 
 				it('matches with just url', () => {
-					expect(fetch)[`toHaveLast${humanVerb}`]('http://example.com/path');
+					expect(expectInput)[`toHaveLast${humanVerb}`](
+						'http://example.com/path',
+					);
 				});
 
 				it('matches with fetch-mock matcher', () => {
-					expect(fetch)[`toHaveLast${humanVerb}`](
+					expect(expectInput)[`toHaveLast${humanVerb}`](
 						'begin:http://example.com/path',
 					);
 				});
 
 				it('matches with matcher and options', () => {
-					expect(fetch)[`toHaveLast${humanVerb}`]('http://example.com/path', {
-						headers: {
-							test: 'header',
+					expect(expectInput)[`toHaveLast${humanVerb}`](
+						'http://example.com/path',
+						{
+							headers: {
+								test: 'header',
+							},
 						},
-					});
+					);
 				});
 
 				it("doesn't match if matcher but not options is correct", () => {
-					expect(fetch).not[`toHaveLast${humanVerb}`](
+					expect(expectInput).not[`toHaveLast${humanVerb}`](
 						'http://example.com/path',
 						{
 							headers: {
@@ -139,7 +159,7 @@ describe('expect extensions', () => {
 				});
 
 				it("doesn't match if options but not matcher is correct", () => {
-					expect(fetch).not[`toHaveLast${humanVerb}`](
+					expect(expectInput).not[`toHaveLast${humanVerb}`](
 						'http://example-no.com/path',
 						{
 							headers: {
@@ -169,18 +189,21 @@ describe('expect extensions', () => {
 				afterAll(() => fetchMock.mockReset());
 
 				it('matches with just url', () => {
-					expect(fetch)[`toHaveNth${humanVerb}`](2, 'http://example2.com/path');
+					expect(expectInput)[`toHaveNth${humanVerb}`](
+						2,
+						'http://example2.com/path',
+					);
 				});
 
 				it('matches with fetch-mock matcher', () => {
-					expect(fetch)[`toHaveNth${humanVerb}`](
+					expect(expectInput)[`toHaveNth${humanVerb}`](
 						2,
 						'begin:http://example2.com/path',
 					);
 				});
 
 				it('matches with matcher and options', () => {
-					expect(fetch)[`toHaveNth${humanVerb}`](
+					expect(expectInput)[`toHaveNth${humanVerb}`](
 						2,
 						'http://example2.com/path',
 						{
@@ -192,7 +215,7 @@ describe('expect extensions', () => {
 				});
 
 				it("doesn't match if matcher but not options is correct", () => {
-					expect(fetch).not[`toHaveNth${humanVerb}`](
+					expect(expectInput).not[`toHaveNth${humanVerb}`](
 						2,
 						'http://example2.com/path',
 						{
@@ -204,7 +227,7 @@ describe('expect extensions', () => {
 				});
 
 				it("doesn't match if options but not matcher is correct", () => {
-					expect(fetch).not[`toHaveNth${humanVerb}`](
+					expect(expectInput).not[`toHaveNth${humanVerb}`](
 						2,
 						'http://example-no.com/path',
 						{
@@ -216,7 +239,7 @@ describe('expect extensions', () => {
 				});
 
 				it("doesn't match if wrong n", () => {
-					expect(fetch).not[`toHaveNth${humanVerb}`](
+					expect(expectInput).not[`toHaveNth${humanVerb}`](
 						1,
 						'http://example2.com/path',
 					);
@@ -242,21 +265,21 @@ describe('expect extensions', () => {
 				afterAll(() => fetchMock.mockReset());
 
 				it('matches with just url', () => {
-					expect(fetch)[`toHave${humanVerb}Times`](
+					expect(expectInput)[`toHave${humanVerb}Times`](
 						2,
 						'http://example.com/path',
 					);
 				});
 
 				it('matches with fetch-mock matcher', () => {
-					expect(fetch)[`toHave${humanVerb}Times`](
+					expect(expectInput)[`toHave${humanVerb}Times`](
 						2,
 						'begin:http://example.com/path',
 					);
 				});
 
 				it('matches with matcher and options', () => {
-					expect(fetch)[`toHave${humanVerb}Times`](
+					expect(expectInput)[`toHave${humanVerb}Times`](
 						2,
 						'http://example.com/path',
 						{
@@ -268,7 +291,7 @@ describe('expect extensions', () => {
 				});
 
 				it("doesn't match if matcher but not options is correct", () => {
-					expect(fetch).not[`toHave${humanVerb}Times`](
+					expect(expectInput).not[`toHave${humanVerb}Times`](
 						2,
 						'http://example.com/path',
 						{
@@ -280,7 +303,7 @@ describe('expect extensions', () => {
 				});
 
 				it("doesn't match if options but not matcher is correct", () => {
-					expect(fetch).not[`toHave${humanVerb}Times`](
+					expect(expectInput).not[`toHave${humanVerb}Times`](
 						2,
 						'http://example-no.com/path',
 						{
@@ -292,14 +315,14 @@ describe('expect extensions', () => {
 				});
 
 				it("doesn't match if too few calls", () => {
-					expect(fetch).not[`toHave${humanVerb}Times`](
+					expect(expectInput).not[`toHave${humanVerb}Times`](
 						1,
 						'http://example.com/path',
 					);
 				});
 
 				it("doesn't match if too many calls", () => {
-					expect(fetch).not[`toHave${humanVerb}Times`](
+					expect(expectInput).not[`toHave${humanVerb}Times`](
 						3,
 						'http://example.com/path',
 					);
@@ -326,15 +349,29 @@ describe('expect extensions', () => {
 		});
 		afterAll(() => fetchMock.mockReset());
 		// it('toBeDone should be falsy only if routes defined', () => {
-		// 	expect(fetch).not.toBeDone();
-		// 	expect(fetch).not.toBeDone('my-route');
+		// 	expect(expectInput).not.toBeDone();
+		// 	expect(expectInput).not.toBeDone('my-route');
 		// });
 		it('matches with just url', () => {
-			expect(fetch).toBeDone('route1');
+			expect(expectInput).toBeDone('route1');
 		});
 
 		it("doesn't match if too few calls", () => {
-			expect(fetch).not.toBeDone('route2');
+			expect(expectInput).not.toBeDone('route2');
+		});
+	});
+});
+
+describe('expect extensions: bad inputs', () => {
+	humanVerbToMethods.forEach((verbs) => {
+		const [humanVerb] = verbs.split(':');
+		it(`${humanVerb} - throws an error if we the input is not patched with fetchMock`, () => {
+			expect(() => {
+				// This simulates a "fetch" implementation that doesn't have fetchMock
+				expect({})[`toHave${humanVerb}`]('http://example.com/path');
+			}).toThrow(
+				'Unable to get fetchMock instance!  Please make sure you passed a patched fetch or fetchMock!',
+			);
 		});
 	});
 });

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -66,8 +66,12 @@ declare global {
 	namespace jest {
 		// Type-narrow expect for FetchMock
 		interface Expect {
-			(actual: FetchMock): FetchMockMatchers;
-			(actual: typeof fetch): FetchMockMatchers;
+			(actual: FetchMock): FetchMockMatchers & {
+				not: FetchMockMatchers;
+			};
+			(actual: typeof fetch): FetchMockMatchers & {
+				not: FetchMockMatchers;
+			};
 		}
 	}
 }

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -67,6 +67,7 @@ declare global {
 		// Type-narrow expect for FetchMock
 		interface Expect {
 			(actual: FetchMock): FetchMockMatchers;
+			(actual: typeof fetch): FetchMockMatchers;
 		}
 	}
 }

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -5,6 +5,8 @@ import {
 } from 'fetch-mock';
 import './jest-extensions.js';
 import type { Jest } from '@jest/environment';
+import type { FetchMockMatchers } from './types.js';
+export { FetchMockMatchers } from './types.js';
 
 type MockResetOptions = {
 	includeSticky: boolean;
@@ -55,3 +57,17 @@ const fetchMockJest = new FetchMockJest({
 });
 
 export default fetchMockJest;
+
+/* eslint-disable @typescript-eslint/no-namespace */
+/**
+ * Export types on the expect object
+ */
+declare global {
+	namespace jest {
+		// Type-narrow expect for FetchMock
+		interface Expect {
+			(actual: FetchMock): FetchMockMatchers;
+		}
+	}
+}
+/* eslint-enable @typescript-eslint/no-namespace */

--- a/packages/jest/src/jest-extensions.ts
+++ b/packages/jest/src/jest-extensions.ts
@@ -6,7 +6,16 @@ import type {
 	CallHistoryFilter,
 	UserRouteConfig,
 } from 'fetch-mock';
-const methodlessExtensions = {
+import {
+	HumanVerbMethodNames,
+	HumanVerbs,
+	RawFetchMockMatchers,
+} from './types.js';
+
+const methodlessExtensions: Pick<
+	RawFetchMockMatchers,
+	HumanVerbMethodNames<'Fetched'>
+> = {
 	toHaveFetched: (
 		{ fetchMock }: { fetchMock: FetchMock },
 		filter: CallHistoryFilter,
@@ -128,25 +137,24 @@ function scopeExpectationNameToMethod(name: string, humanVerb: string): string {
 	return name.replace('Fetched', humanVerb);
 }
 
-[
-	'Got:get',
-	'Posted:post',
-	'Put:put',
-	'Deleted:delete',
-	'FetchedHead:head',
-	'Patched:patch',
-].forEach((verbs) => {
-	const [humanVerb, method] = verbs.split(':');
+const expectMethodNameToMethodMap: {
+	[humanVerb in Exclude<HumanVerbs, 'Fetched'>]: string;
+} = {
+	Got: 'get',
+	Posted: 'post',
+	Put: 'put',
+	Deleted: 'delete',
+	FetchedHead: 'head',
+	Patched: 'patch',
+};
 
-	const extensions: {
-		// eslint-disable-next-line  @typescript-eslint/no-explicit-any
-		[key: string]: (...args: any[]) => SyncExpectationResult;
-	} = Object.fromEntries(
+Object.entries(expectMethodNameToMethodMap).forEach(([humanVerb, method]) => {
+	const extensions = Object.fromEntries(
 		Object.entries(methodlessExtensions).map(([name, func]) => [
 			scopeExpectationNameToMethod(name, humanVerb),
 			scopeExpectationFunctionToMethod(func, method),
 		]),
-	);
+	) as Omit<RawFetchMockMatchers, HumanVerbMethodNames<'Fetched'>>;
 
 	expect.extend(extensions);
 });

--- a/packages/jest/src/types.ts
+++ b/packages/jest/src/types.ts
@@ -72,11 +72,18 @@ export type FetchMockMatchers = {
 
 // types for use doing some intermediate type checking in extensions to make sure things don't get out of sync
 /**
+ * This reflects the Object.assign that FetchMock does on the fetch function
+ */
+export type PatchedFetch = {
+	fetchMock: FetchMock;
+};
+
+/**
  * This type allows us to take the Matcher type and creat another one
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RawMatcher<T extends (...args: any[]) => any> = (
-	input: { fetchMock: FetchMock },
+	input: PatchedFetch | FetchMock,
 	...args: Parameters<T>
 ) => ReturnType<T>;
 

--- a/packages/jest/src/types.ts
+++ b/packages/jest/src/types.ts
@@ -1,0 +1,91 @@
+import type { CallHistoryFilter, FetchMock, UserRouteConfig } from 'fetch-mock';
+import type { SyncExpectationResult } from 'expect';
+
+export type HumanVerbs =
+	| 'Got'
+	| 'Posted'
+	| 'Put'
+	| 'Deleted'
+	| 'FetchedHead'
+	| 'Patched'
+	| 'Fetched';
+
+/**
+ * Verify that a particular call for the HTTP method implied in the function name
+ * has occurred
+ */
+export type ToHaveFunc = (
+	filter: CallHistoryFilter,
+	options: UserRouteConfig,
+) => SyncExpectationResult;
+
+/**
+ * Verify that a particular Nth call for the HTTP method implied in the function name
+ * has occurred
+ */
+export type ToHaveNthFunc = (
+	n: number,
+	filter: CallHistoryFilter,
+	options: UserRouteConfig,
+) => SyncExpectationResult;
+
+/**
+ * Verify that a particular call for the HTTP method implied in the function name
+ * has been made N times
+ */
+export type ToHaveTimesFunc = (
+	times: number,
+	filter: CallHistoryFilter,
+	options: UserRouteConfig,
+) => SyncExpectationResult;
+
+export type FetchMockMatchers = {
+	toHaveFetched: ToHaveFunc;
+	toHaveLastFetched: ToHaveFunc;
+	toHaveFetchedTimes: ToHaveTimesFunc;
+	toHaveNthFetched: ToHaveNthFunc;
+	toHaveGot: ToHaveFunc;
+	toHaveLastGot: ToHaveFunc;
+	toHaveGotTimes: ToHaveTimesFunc;
+	toHaveNthGot: ToHaveNthFunc;
+	toHavePosted: ToHaveFunc;
+	toHaveLastPosted: ToHaveFunc;
+	toHavePostedTimes: ToHaveTimesFunc;
+	toHaveNthPosted: ToHaveNthFunc;
+	toHavePut: ToHaveFunc;
+	toHaveLastPut: ToHaveFunc;
+	toHavePutTimes: ToHaveTimesFunc;
+	toHaveNthPut: ToHaveNthFunc;
+	toHaveDeleted: ToHaveFunc;
+	toHaveLastDeleted: ToHaveFunc;
+	toHaveDeletedTimes: ToHaveTimesFunc;
+	toHaveNthDeleted: ToHaveNthFunc;
+	toHaveFetchedHead: ToHaveFunc;
+	toHaveLastFetchedHead: ToHaveFunc;
+	toHaveFetchedHeadTimes: ToHaveTimesFunc;
+	toHaveNthFetchedHead: ToHaveNthFunc;
+	toHavePatched: ToHaveFunc;
+	toHaveLastPatched: ToHaveFunc;
+	toHavePatchedTimes: ToHaveTimesFunc;
+	toHaveNthPatched: ToHaveNthFunc;
+};
+
+// types for use doing some intermediate type checking in extensions to make sure things don't get out of sync
+/**
+ * This type allows us to take the Matcher type and creat another one
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RawMatcher<T extends (...args: any[]) => any> = (
+	input: { fetchMock: FetchMock },
+	...args: Parameters<T>
+) => ReturnType<T>;
+
+export type RawFetchMockMatchers = {
+	[k in keyof FetchMockMatchers]: RawMatcher<FetchMockMatchers[k]>;
+};
+
+export type HumanVerbMethodNames<M extends HumanVerbs> =
+	| `toHave${M}`
+	| `toHaveLast${M}`
+	| `toHave${M}Times`
+	| `toHaveNth${M}`;


### PR DESCRIPTION
# Summary

This adds types to describe the FetchMockAdapters and updates the jest Expect object so that typescript and intellisense can provide correct typings.  It also adds some typings to the extension.js code so that, if something changes, we'll see that the types fail to compile and we can make updates as needed.

## Update - Additional Commit

This commit keeps support for the "patched fetch" and also adds support for FetchMock like the documentation details.  It adds tests for both inputs and adds an error message if the input is neither FetchMock or a patched fetch instance.