### PR TITLE
fix: route may be undefined when no match

### DIFF
--- a/packages/fetch-mock/src/CallHistory.ts
+++ b/packages/fetch-mock/src/CallHistory.ts
@@ -84,11 +84,11 @@ class CallHistory {
 
 		if (isMatchedOrUnmatched(filter)) {
 			if (([true, 'matched'] as CallHistoryFilter[]).includes(filter)) {
-				calls = calls.filter(({ route }) => !route.config.isFallback);
+				calls = calls.filter((call) => !call.route?.config.isFallback);
 			} else if (
 				([false, 'unmatched'] as CallHistoryFilter[]).includes(filter)
 			) {
-				calls = calls.filter(({ route }) => Boolean(route.config.isFallback));
+				calls = calls.filter((call) => Boolean(call.route?.config.isFallback));
 			}
 
 			if (!options) {
@@ -96,11 +96,7 @@ class CallHistory {
 			}
 		} else if (isName(filter)) {
 			calls = calls.filter(
-				({
-					route: {
-						config: { name },
-					},
-				}) => name === filter,
+				(call) => call.route?.config.name === filter,
 			);
 			if (!options) {
 				return calls;


### PR DESCRIPTION
When we just mock one route, if we have more requests than the one mocked, they dont have `.route` in callHistory. that result in JS error `(destructured parameter).route is undefined`

```
    fetchMock.mockGlobal();
    fetchMock.put('/documents', 200, 'updateDocuments');
    // remove line below and then its not working anymore
    fetchMock.route('*', 200);

    await $('>>>.chip.contract').click();
    await fetchMock.callHistory.flush(true);

    expect(
      fetchMock.callHistory.called('updateDocuments')
    ).toBe(true);
```

I may miss something, but the code change seems to fix this issue