### PR TITLE
fix: incorrect Jest matcher extension TypeScript type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
 				"eslint": "9.14.0",
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-prettier": "^5.2.1",
+				"expect-type": "^1.1.0",
 				"globals": "^15.9.0",
 				"husky": "^9.0.11",
 				"jest": "^29.7.0",
@@ -12852,7 +12853,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
 			"integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
-			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"eslint": "9.14.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-prettier": "^5.2.1",
+		"expect-type": "^1.1.0",
 		"globals": "^15.9.0",
 		"husky": "^9.0.11",
 		"jest": "^29.7.0",

--- a/packages/jest/src/__tests__/extensions.spec.ts
+++ b/packages/jest/src/__tests__/extensions.spec.ts
@@ -1,17 +1,17 @@
-import { describe, it, beforeAll, afterAll, expect } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 
-import fetchMockModule from '../index';
-const fetchMock = fetchMockModule.default;
+import fetchMock from '../index';
+import { expectTypeOf } from 'expect-type';
 
 const humanVerbToMethods = [
-	'Fetched',
-	'Got:get',
-	'Posted:post',
-	'Put:put',
-	'Deleted:delete',
-	'FetchedHead:head',
-	'Patched:patch',
-];
+	{ humanVerb: 'Fetched', method: 'get' },
+	{ humanVerb: 'Got', method: 'get' },
+	{ humanVerb: 'Posted', method: 'post' },
+	{ humanVerb: 'Put', method: 'put' },
+	{ humanVerb: 'Deleted', method: 'delete' },
+	{ humanVerb: 'FetchedHead', method: 'head' },
+	{ humanVerb: 'Patched', method: 'patch' },
+] as const;
 
 // initialize a mock here so fetch is patched across all tests
 fetchMock.mockGlobal();
@@ -20,8 +20,7 @@ describe.each([
 	['patched fetch input', fetch],
 	['fetchMock input', fetchMock],
 ])('expect extensions %s', (_str, expectInput) => {
-	humanVerbToMethods.forEach((verbs) => {
-		const [humanVerb, method] = verbs.split(':');
+	humanVerbToMethods.forEach(({ humanVerb, method }) => {
 		describe(`${humanVerb} expectations`, () => {
 			describe('when no calls', () => {
 				beforeAll(() => {
@@ -29,18 +28,21 @@ describe.each([
 				});
 				afterAll(() => fetchMock.mockReset());
 				it(`toHave${humanVerb} should be falsy`, () => {
+					expect(expectInput).not[`toHave${humanVerb}`]();
 					expect(expectInput).not[`toHave${humanVerb}`](
 						'http://example.com/path',
 					);
 				});
 
 				it(`toHaveLast${humanVerb} should be falsy`, () => {
+					expect(expectInput).not[`toHaveLast${humanVerb}`]();
 					expect(expectInput).not[`toHaveLast${humanVerb}`](
 						'http://example.com/path',
 					);
 				});
 
 				it(`toHaveNth${humanVerb} should be falsy`, () => {
+					expect(expectInput).not[`toHaveNth${humanVerb}`](1);
 					expect(expectInput).not[`toHaveNth${humanVerb}`](
 						1,
 						'http://example.com/path',
@@ -48,6 +50,7 @@ describe.each([
 				});
 
 				it(`toHave${humanVerb}Times should be falsy`, () => {
+					expect(expectInput).not[`toHave${humanVerb}Times`](1);
 					expect(expectInput).not[`toHave${humanVerb}Times`](
 						1,
 						'http://example.com/path',
@@ -58,19 +61,23 @@ describe.each([
 				beforeAll(() => {
 					fetchMock.mockGlobal().route('*', 200);
 					fetch('http://example.com/path2', {
-						method: method || 'get',
+						method,
 						headers: {
 							test: 'header',
 						},
 					});
 					fetch('http://example.com/path', {
-						method: method || 'get',
+						method,
 						headers: {
 							test: 'header',
 						},
 					});
 				});
 				afterAll(() => fetchMock.mockReset());
+
+				it('matches without any matcher supplied', () => {
+					expect(expectInput)[`toHave${humanVerb}`]();
+				});
 
 				it('matches with just url', () => {
 					expect(expectInput)[`toHave${humanVerb}`]('http://example.com/path');
@@ -111,18 +118,29 @@ describe.each([
 						},
 					);
 				});
+
+				it('should not be any', () => {
+					expectTypeOf(expect(expectInput)[`toHave${humanVerb}`]).not.toBeAny();
+					expectTypeOf(
+						expect(expectInput).not[`toHave${humanVerb}`],
+					).not.toBeAny();
+				});
 			});
 			describe(`toHaveLast${humanVerb}`, () => {
 				beforeAll(() => {
 					fetchMock.mockGlobal().route('*', 200);
 					fetch('http://example.com/path', {
-						method: method || 'get',
+						method,
 						headers: {
 							test: 'header',
 						},
 					});
 				});
 				afterAll(() => fetchMock.mockReset());
+
+				it('matches without any matcher supplied', () => {
+					expect(expectInput)[`toHaveLast${humanVerb}`]();
+				});
 
 				it('matches with just url', () => {
 					expect(expectInput)[`toHaveLast${humanVerb}`](
@@ -168,25 +186,38 @@ describe.each([
 						},
 					);
 				});
+
+				it('should not be any', () => {
+					expectTypeOf(
+						expect(expectInput)[`toHaveLast${humanVerb}`],
+					).not.toBeAny();
+					expectTypeOf(
+						expect(expectInput).not[`toHaveLast${humanVerb}`],
+					).not.toBeAny();
+				});
 			});
 
 			describe(`toHaveNth${humanVerb}`, () => {
 				beforeAll(() => {
 					fetchMock.mockGlobal().route('*', 200);
 					fetch('http://example1.com/path', {
-						method: method || 'get',
+						method,
 						headers: {
 							test: 'header',
 						},
 					});
 					fetch('http://example2.com/path', {
-						method: method || 'get',
+						method,
 						headers: {
 							test: 'header',
 						},
 					});
 				});
 				afterAll(() => fetchMock.mockReset());
+
+				it('matches without any matcher supplied', () => {
+					expect(expectInput)[`toHaveNth${humanVerb}`](2);
+				});
 
 				it('matches with just url', () => {
 					expect(expectInput)[`toHaveNth${humanVerb}`](
@@ -244,25 +275,38 @@ describe.each([
 						'http://example2.com/path',
 					);
 				});
+
+				it('should not be any', () => {
+					expectTypeOf(
+						expect(expectInput)[`toHaveNth${humanVerb}`],
+					).not.toBeAny();
+					expectTypeOf(
+						expect(expectInput).not[`toHaveNth${humanVerb}`],
+					).not.toBeAny();
+				});
 			});
 
 			describe(`toHave${humanVerb}Times`, () => {
 				beforeAll(() => {
 					fetchMock.mockGlobal().route('*', 200);
 					fetch('http://example.com/path', {
-						method: method || 'get',
+						method,
 						headers: {
 							test: 'header',
 						},
 					});
 					fetch('http://example.com/path', {
-						method: method || 'get',
+						method,
 						headers: {
 							test: 'header',
 						},
 					});
 				});
 				afterAll(() => fetchMock.mockReset());
+
+				it('matches without any matcher supplied', () => {
+					expect(expectInput)[`toHave${humanVerb}Times`](2);
+				});
 
 				it('matches with just url', () => {
 					expect(expectInput)[`toHave${humanVerb}Times`](
@@ -327,6 +371,15 @@ describe.each([
 						'http://example.com/path',
 					);
 				});
+
+				it('should not be any', () => {
+					expectTypeOf(
+						expect(expectInput)[`toHave${humanVerb}Times`],
+					).not.toBeAny();
+					expectTypeOf(
+						expect(expectInput).not[`toHave${humanVerb}Times`],
+					).not.toBeAny();
+				});
 			});
 		});
 	});
@@ -359,12 +412,16 @@ describe.each([
 		it("doesn't match if too few calls", () => {
 			expect(expectInput).not.toBeDone('route2');
 		});
+
+		it('should not be any', () => {
+			expectTypeOf(expect(expectInput).toBeDone).not.toBeAny();
+			expectTypeOf(expect(expectInput).not.toBeDone).not.toBeAny();
+		});
 	});
 });
 
 describe('expect extensions: bad inputs', () => {
-	humanVerbToMethods.forEach((verbs) => {
-		const [humanVerb] = verbs.split(':');
+	humanVerbToMethods.forEach(({ humanVerb }) => {
 		it(`${humanVerb} - throws an error if we the input is not patched with fetchMock`, () => {
 			expect(() => {
 				// This simulates a "fetch" implementation that doesn't have fetchMock

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -76,3 +76,8 @@ declare global {
 	}
 }
 /* eslint-enable @typescript-eslint/no-namespace */
+
+declare module '@jest/expect' {
+	// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+	interface Matchers<R> extends FetchMockMatchers<R> {}
+}

--- a/packages/jest/src/jest-extensions.ts
+++ b/packages/jest/src/jest-extensions.ts
@@ -172,7 +172,7 @@ Object.entries(expectMethodNameToMethodMap).forEach(([humanVerb, method]) => {
 			scopeExpectationNameToMethod(name, humanVerb),
 			scopeExpectationFunctionToMethod(func, method),
 		]),
-	) as Omit<RawFetchMockMatchers, HumanVerbMethodNames<'Fetched'>>;
+	) as Omit<RawFetchMockMatchers, HumanVerbMethodNames<'Fetched'> | 'toBeDone'>;
 
 	expect.extend(extensions);
 });

--- a/packages/jest/src/types.ts
+++ b/packages/jest/src/types.ts
@@ -1,4 +1,9 @@
-import type { CallHistoryFilter, FetchMock, UserRouteConfig } from 'fetch-mock';
+import type {
+	CallHistoryFilter,
+	FetchMock,
+	RouteName,
+	UserRouteConfig,
+} from 'fetch-mock';
 import type { SyncExpectationResult } from 'expect';
 
 export type HumanVerbs =
@@ -14,60 +19,66 @@ export type HumanVerbs =
  * Verify that a particular call for the HTTP method implied in the function name
  * has occurred
  */
-export type ToHaveFunc = (
-	filter: CallHistoryFilter,
-	options: UserRouteConfig,
-) => SyncExpectationResult;
+export type ToHaveFunc<R> = (
+	filter?: CallHistoryFilter,
+	options?: UserRouteConfig,
+) => R;
 
 /**
  * Verify that a particular Nth call for the HTTP method implied in the function name
  * has occurred
  */
-export type ToHaveNthFunc = (
+export type ToHaveNthFunc<R> = (
 	n: number,
-	filter: CallHistoryFilter,
-	options: UserRouteConfig,
-) => SyncExpectationResult;
+	filter?: CallHistoryFilter,
+	options?: UserRouteConfig,
+) => R;
 
 /**
  * Verify that a particular call for the HTTP method implied in the function name
  * has been made N times
  */
-export type ToHaveTimesFunc = (
+export type ToHaveTimesFunc<R> = (
 	times: number,
-	filter: CallHistoryFilter,
-	options: UserRouteConfig,
-) => SyncExpectationResult;
+	filter?: CallHistoryFilter,
+	options?: UserRouteConfig,
+) => R;
 
-export type FetchMockMatchers = {
-	toHaveFetched: ToHaveFunc;
-	toHaveLastFetched: ToHaveFunc;
-	toHaveFetchedTimes: ToHaveTimesFunc;
-	toHaveNthFetched: ToHaveNthFunc;
-	toHaveGot: ToHaveFunc;
-	toHaveLastGot: ToHaveFunc;
-	toHaveGotTimes: ToHaveTimesFunc;
-	toHaveNthGot: ToHaveNthFunc;
-	toHavePosted: ToHaveFunc;
-	toHaveLastPosted: ToHaveFunc;
-	toHavePostedTimes: ToHaveTimesFunc;
-	toHaveNthPosted: ToHaveNthFunc;
-	toHavePut: ToHaveFunc;
-	toHaveLastPut: ToHaveFunc;
-	toHavePutTimes: ToHaveTimesFunc;
-	toHaveNthPut: ToHaveNthFunc;
-	toHaveDeleted: ToHaveFunc;
-	toHaveLastDeleted: ToHaveFunc;
-	toHaveDeletedTimes: ToHaveTimesFunc;
-	toHaveNthDeleted: ToHaveNthFunc;
-	toHaveFetchedHead: ToHaveFunc;
-	toHaveLastFetchedHead: ToHaveFunc;
-	toHaveFetchedHeadTimes: ToHaveTimesFunc;
-	toHaveNthFetchedHead: ToHaveNthFunc;
-	toHavePatched: ToHaveFunc;
-	toHaveLastPatched: ToHaveFunc;
-	toHavePatchedTimes: ToHaveTimesFunc;
-	toHaveNthPatched: ToHaveNthFunc;
+/**
+ * Verify that a particular route names(s) has been called
+ */
+export type ToBeDoneFunc<R> = (routes?: RouteName | RouteName[]) => R;
+
+export type FetchMockMatchers<R = void> = {
+	toHaveFetched: ToHaveFunc<R>;
+	toHaveLastFetched: ToHaveFunc<R>;
+	toHaveFetchedTimes: ToHaveTimesFunc<R>;
+	toHaveNthFetched: ToHaveNthFunc<R>;
+	toHaveGot: ToHaveFunc<R>;
+	toHaveLastGot: ToHaveFunc<R>;
+	toHaveGotTimes: ToHaveTimesFunc<R>;
+	toHaveNthGot: ToHaveNthFunc<R>;
+	toHavePosted: ToHaveFunc<R>;
+	toHaveLastPosted: ToHaveFunc<R>;
+	toHavePostedTimes: ToHaveTimesFunc<R>;
+	toHaveNthPosted: ToHaveNthFunc<R>;
+	toHavePut: ToHaveFunc<R>;
+	toHaveLastPut: ToHaveFunc<R>;
+	toHavePutTimes: ToHaveTimesFunc<R>;
+	toHaveNthPut: ToHaveNthFunc<R>;
+	toHaveDeleted: ToHaveFunc<R>;
+	toHaveLastDeleted: ToHaveFunc<R>;
+	toHaveDeletedTimes: ToHaveTimesFunc<R>;
+	toHaveNthDeleted: ToHaveNthFunc<R>;
+	toHaveFetchedHead: ToHaveFunc<R>;
+	toHaveLastFetchedHead: ToHaveFunc<R>;
+	toHaveFetchedHeadTimes: ToHaveTimesFunc<R>;
+	toHaveNthFetchedHead: ToHaveNthFunc<R>;
+	toHavePatched: ToHaveFunc<R>;
+	toHaveLastPatched: ToHaveFunc<R>;
+	toHavePatchedTimes: ToHaveTimesFunc<R>;
+	toHaveNthPatched: ToHaveNthFunc<R>;
+	toBeDone: ToBeDoneFunc<R>;
 };
 
 // types for use doing some intermediate type checking in extensions to make sure things don't get out of sync
@@ -88,7 +99,9 @@ type RawMatcher<T extends (...args: any[]) => any> = (
 ) => ReturnType<T>;
 
 export type RawFetchMockMatchers = {
-	[k in keyof FetchMockMatchers]: RawMatcher<FetchMockMatchers[k]>;
+	[k in keyof FetchMockMatchers<SyncExpectationResult>]: RawMatcher<
+		FetchMockMatchers<SyncExpectationResult>[k]
+	>;
 };
 
 export type HumanVerbMethodNames<M extends HumanVerbs> =


### PR DESCRIPTION
Related: https://github.com/wheresrhys/fetch-mock/pull/880

There were some incorrect Jest matcher types in the above PR: 
* The `filter` and `options` parameters should be optional
* The returned type of `SyncExpectationResult` should not be exposed as it should only be used for `expect.extend()`. 
* The `.toBeDone()` matcher type is missing. 
* The matchers types are missing when using `import { expect } from '@jest/globals'`

The following has been done to fix these issues:
* Updating the `ToHaveFunc`, `ToHaveNthFunc` and `ToHaveTimesFunc` signatures to make the `filter` and `options` parameters optional. The spec has also been updated to test when those two parameters are not present.
* Those three function signatures have also been updated to take a generic parameter, so they can be used in `RawFetchMockMatchers` (just for `expect.extend()`), or used in the extended `Matchers` interface.
* Adding the `.toBeDone()` matcher type
* Add module declaration for `@jest/expect` so using `import { expect } from '@jest/globals'` will have types too.
* Change the extension spec file from `.js` to `.ts` and check the types of the matchers with `expect-type`