### PR TITLE
Change `lastCall` return type to `CallLog | undefined`

### DIFF
--- a/packages/fetch-mock/src/CallHistory.ts
+++ b/packages/fetch-mock/src/CallHistory.ts
@@ -127,7 +127,10 @@ class CallHistory {
 	called(filter?: CallHistoryFilter, options?: RouteConfig): boolean {
 		return Boolean(this.calls(filter, options).length);
 	}
-	lastCall(filter?: CallHistoryFilter, options?: RouteConfig): CallLog | undefined {
+	lastCall(
+		filter?: CallHistoryFilter,
+		options?: RouteConfig,
+	): CallLog | undefined {
 		return this.calls(filter, options).pop();
 	}
 

--- a/packages/fetch-mock/src/CallHistory.ts
+++ b/packages/fetch-mock/src/CallHistory.ts
@@ -127,7 +127,7 @@ class CallHistory {
 	called(filter?: CallHistoryFilter, options?: RouteConfig): boolean {
 		return Boolean(this.calls(filter, options).length);
 	}
-	lastCall(filter?: CallHistoryFilter, options?: RouteConfig): CallLog | void {
+	lastCall(filter?: CallHistoryFilter, options?: RouteConfig): CallLog | undefined {
 		return this.calls(filter, options).pop();
 	}
 


### PR DESCRIPTION
This PR changes the return type of `CallHistory.lastCall` from `CallLog | void` to `CallLog | undefined`.

This matches the return type of [Array.pop](https://github.com/microsoft/TypeScript/blob/ea93ee6db9441eb51a1d816e114b0468363dcd9c/lib/lib.es5.d.ts#L1236)