### PR TITLE
fix: allow matching body for delete requests

### DIFF
--- a/packages/fetch-mock/src/Matchers.ts
+++ b/packages/fetch-mock/src/Matchers.ts
@@ -212,7 +212,7 @@ const getBodyMatcher: MatcherGenerator = (route) => {
 	}
 
 	return ({ options: { body, method = 'get' } }) => {
-		if (['get', 'head', 'delete'].includes(method.toLowerCase())) {
+		if (['get', 'head'].includes(method.toLowerCase())) {
 			// GET requests don’t send a body so even if it exists in the options
 			// we treat as no body because it would never actually make it to the server
 			// in the application code

--- a/packages/fetch-mock/src/__tests__/Matchers/body.test.js
+++ b/packages/fetch-mock/src/__tests__/Matchers/body.test.js
@@ -144,6 +144,25 @@ describe('body matching', () => {
 			).toBe(true);
 		});
 
+		it('should match if request is delete', () => {
+			const route = new Route({
+				body: { foo: 'bar' },
+				method: 'delete',
+				response: 200,
+			});
+
+			expect(
+				route.matcher({
+					url: 'http://a.com/',
+					options: {
+						method: 'DELETE',
+						body: JSON.stringify({ foo: 'bar' }),
+						headers: { 'Content-Type': 'application/json' },
+					},
+				}),
+			).toBe(true);
+		});
+
 		describe('partial body matching', () => {
 			it('match when missing properties', () => {
 				const route = new Route({


### PR DESCRIPTION
Request bodies were ignored for DELETE requests (along with GET and HEAD requests) in #749, but DELETE requests can specify a body and it works with the `fetch-mock` library. As per [this MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch), only GET and HEAD requests cannot specify a body.

A test was added to verify that this works and this was also verified in a consuming library.
