### PR TITLE
doc: update quickstart example

### DIFF
--- a/docs/docs/Usage/quickstart.md
+++ b/docs/docs/Usage/quickstart.md
@@ -43,13 +43,13 @@ fetchMock
 
 You can use the names you gave your routes to check if they have been called.
 
-- `fetchMock.called(name)` reports if any calls were handled by your route. If you just want to check `fetch` was called at all then do not pass in a name.
-- `fetchMock.lastCall(name)` will return a CallLog object that will give you access to lots of metadata about the call, including the original arguments passed in to `fetch`.
-- `fetchMock.done()` will tell you if `fetch` was called the expected number of times.
+- `fetchMock.callHistory.called(name)` reports if any calls were handled by your route. If you just want to check `fetch` was called at all then do not pass in a name.
+- `fetchMock.callHistory.lastCall(name)` will return a CallLog object that will give you access to lots of metadata about the call, including the original arguments passed in to `fetch`.
+- `fetchMock.callHistory.done()` will tell you if `fetch` was called the expected number of times.
 
 ```js
-assert(fetchMock.called('good get'));
-assertEqual(fetchMock.lastCall('good get').query['search'], 'needle');
+assert(fetchMock.callHistory.called('good get'));
+assert(fetchMock.callHistory.lastCall('good get').queryParams.get('search'), 'needle');
 ```
 
 ## Tearing down your mock


### PR DESCRIPTION
When I follow the example, I got error `the property ... does not exist on type FetchMock`

<img width="596" alt="image" src="https://github.com/user-attachments/assets/81c09851-ba4c-4cc3-8c08-37b19626f827" />

I believe now we have to access those method under the `callHistory` property instead of directly undef fetchMock, so update the doc accordingly